### PR TITLE
fix: address P0 and P1 code review findings

### DIFF
--- a/src/Cmux.Cli/Cmux.Cli.csproj
+++ b/src/Cmux.Cli/Cmux.Cli.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Cmux.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Cmux.Core\Cmux.Core.csproj" />
   </ItemGroup>
 

--- a/src/Cmux.Cli/Program.cs
+++ b/src/Cmux.Cli/Program.cs
@@ -157,7 +157,7 @@ public static class Program
         return 0;
     }
 
-    private static Dictionary<string, string> ParseArgs(string[] args)
+    internal static Dictionary<string, string> ParseArgs(string[] args)
     {
         var result = new Dictionary<string, string>();
         int positional = 0;

--- a/src/Cmux.Core/Cmux.Core.csproj
+++ b/src/Cmux.Core/Cmux.Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Management" Version="9.0.3" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
   </ItemGroup>

--- a/src/Cmux.Core/IPC/DaemonClient.cs
+++ b/src/Cmux.Core/IPC/DaemonClient.cs
@@ -16,6 +16,7 @@ public sealed class DaemonClient : IDisposable
 
     // Synchronization: only one request at a time, listen loop feeds response back via TCS
     private readonly SemaphoreSlim _requestLock = new(1, 1);
+    private readonly object _pendingLock = new();
     private TaskCompletionSource<DaemonResponse?>? _pendingResponse;
 
     public bool IsConnected => _pipe?.IsConnected == true && _connected;
@@ -202,20 +203,28 @@ public sealed class DaemonClient : IDisposable
                 if (line == null) break;
 
                 // Try to parse as a DaemonResponse first (if a request is pending)
-                if (_pendingResponse != null)
+                TaskCompletionSource<DaemonResponse?>? pendingTcs;
+                lock (_pendingLock)
+                {
+                    pendingTcs = _pendingResponse;
+                }
+
+                if (pendingTcs != null)
                 {
                     try
                     {
                         var response = JsonSerializer.Deserialize<DaemonResponse>(line);
-                        if (response != null && _pendingResponse != null)
+                        if (response != null)
                         {
                             // Responses have Success property; events have Type property
                             // Check if this looks like a response (has Success field)
                             if (line.Contains("\"Success\"", StringComparison.OrdinalIgnoreCase))
                             {
-                                var tcs = _pendingResponse;
-                                _pendingResponse = null;
-                                tcs.TrySetResult(response);
+                                lock (_pendingLock)
+                                {
+                                    _pendingResponse = null;
+                                }
+                                pendingTcs.TrySetResult(response);
                                 continue;
                             }
                         }
@@ -240,7 +249,13 @@ public sealed class DaemonClient : IDisposable
         finally
         {
             _connected = false; // Prevent new requests from entering SendRequestAsync
-            _pendingResponse?.TrySetResult(null);
+            TaskCompletionSource<DaemonResponse?>? remaining;
+            lock (_pendingLock)
+            {
+                remaining = _pendingResponse;
+                _pendingResponse = null;
+            }
+            remaining?.TrySetResult(null);
             Disconnected?.Invoke();
         }
     }
@@ -303,7 +318,10 @@ public sealed class DaemonClient : IDisposable
         try
         {
             var tcs = new TaskCompletionSource<DaemonResponse?>();
-            _pendingResponse = tcs;
+            lock (_pendingLock)
+            {
+                _pendingResponse = tcs;
+            }
 
             var json = JsonSerializer.Serialize(request);
             if (request.Type != DaemonMessageTypes.SessionWrite)
@@ -316,7 +334,7 @@ public sealed class DaemonClient : IDisposable
             catch (IOException)
             {
                 _connected = false;
-                _pendingResponse = null;
+                lock (_pendingLock) { _pendingResponse = null; }
                 return null;
             }
 
@@ -331,7 +349,7 @@ public sealed class DaemonClient : IDisposable
         catch (Exception ex)
         {
             LogDaemon($"[SendRequest] Exception: {ex.GetType().Name}: {ex.Message}");
-            _pendingResponse = null;
+            lock (_pendingLock) { _pendingResponse = null; }
             return null;
         }
         finally

--- a/src/Cmux.Core/IPC/NamedPipeServer.cs
+++ b/src/Cmux.Core/IPC/NamedPipeServer.cs
@@ -1,4 +1,6 @@
 using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text;
 using System.Text.Json;
 
@@ -34,18 +36,34 @@ public sealed class NamedPipeServer : IDisposable
         _listenTask = Task.Run(() => ListenLoop(_cts.Token));
     }
 
+    private static PipeSecurity CreatePipeSecurity()
+    {
+        var security = new PipeSecurity();
+        var currentUser = WindowsIdentity.GetCurrent().User!;
+        security.AddAccessRule(new PipeAccessRule(
+            currentUser,
+            PipeAccessRights.FullControl,
+            AccessControlType.Allow));
+        return security;
+    }
+
     private async Task ListenLoop(CancellationToken ct)
     {
+        var pipeSecurity = CreatePipeSecurity();
+
         while (!ct.IsCancellationRequested)
         {
             try
             {
-                var pipe = new NamedPipeServerStream(
+                var pipe = NamedPipeServerStreamAcl.Create(
                     _pipeName,
                     PipeDirection.InOut,
                     NamedPipeServerStream.MaxAllowedServerInstances,
                     PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous);
+                    PipeOptions.Asynchronous,
+                    inBufferSize: 0,
+                    outBufferSize: 0,
+                    pipeSecurity);
 
                 await pipe.WaitForConnectionAsync(ct);
 

--- a/src/Cmux.Core/Services/SecretStoreService.cs
+++ b/src/Cmux.Core/Services/SecretStoreService.cs
@@ -1,10 +1,12 @@
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace Cmux.Core.Services;
 
 /// <summary>
 /// Stores secrets encrypted with Windows DPAPI in %LOCALAPPDATA%/cmux/secrets.json.
+/// Each stored value is the Base64 encoding of: HMAC(32 bytes) || DPAPI ciphertext.
 /// </summary>
 public static class SecretStoreService
 {
@@ -13,6 +15,9 @@ public static class SecretStoreService
 
     private static readonly string SecretsPath =
         Path.Combine(SecretsDir, "secrets.json");
+
+    // Additional entropy for DPAPI to bind ciphertext to this application
+    private static readonly byte[] Entropy = "cmux-secret-store-v1"u8.ToArray();
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -31,9 +36,27 @@ public static class SecretStoreService
             if (!map.TryGetValue(secretName, out var encoded) || string.IsNullOrWhiteSpace(encoded))
                 return null;
 
-            var encrypted = Convert.FromBase64String(encoded);
-            var plain = ProtectedData.Unprotect(encrypted, optionalEntropy: null, DataProtectionScope.CurrentUser);
-            return System.Text.Encoding.UTF8.GetString(plain);
+            var blob = Convert.FromBase64String(encoded);
+
+            // Try new format: HMAC(32) || ciphertext
+            if (blob.Length > 32)
+            {
+                var storedHmac = blob[..32];
+                var ciphertext = blob[32..];
+
+                var plain = ProtectedData.Unprotect(ciphertext, Entropy, DataProtectionScope.CurrentUser);
+
+                // Verify integrity
+                var computedHmac = ComputeHmac(ciphertext);
+                if (!CryptographicOperations.FixedTimeEquals(storedHmac, computedHmac))
+                    return null; // Integrity check failed
+
+                return Encoding.UTF8.GetString(plain);
+            }
+
+            // Fallback: legacy format without HMAC (no entropy)
+            var legacyPlain = ProtectedData.Unprotect(blob, optionalEntropy: null, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(legacyPlain);
         }
         catch
         {
@@ -56,9 +79,16 @@ public static class SecretStoreService
             }
             else
             {
-                var plain = System.Text.Encoding.UTF8.GetBytes(value);
-                var encrypted = ProtectedData.Protect(plain, optionalEntropy: null, DataProtectionScope.CurrentUser);
-                map[secretName] = Convert.ToBase64String(encrypted);
+                var plain = Encoding.UTF8.GetBytes(value);
+                var ciphertext = ProtectedData.Protect(plain, Entropy, DataProtectionScope.CurrentUser);
+                var hmac = ComputeHmac(ciphertext);
+
+                // Store as HMAC || ciphertext
+                var blob = new byte[hmac.Length + ciphertext.Length];
+                hmac.CopyTo(blob, 0);
+                ciphertext.CopyTo(blob, hmac.Length);
+
+                map[secretName] = Convert.ToBase64String(blob);
             }
 
             SaveRawSecrets(map);
@@ -67,6 +97,12 @@ public static class SecretStoreService
         {
             // Ignore secret persistence errors to avoid crashing the app.
         }
+    }
+
+    private static byte[] ComputeHmac(byte[] data)
+    {
+        using var hmac = new HMACSHA256(Entropy);
+        return hmac.ComputeHash(data);
     }
 
     public static void RemoveSecret(string secretName)

--- a/src/Cmux.Core/Services/SecretStoreService.cs
+++ b/src/Cmux.Core/Services/SecretStoreService.cs
@@ -6,7 +6,7 @@ namespace Cmux.Core.Services;
 
 /// <summary>
 /// Stores secrets encrypted with Windows DPAPI in %LOCALAPPDATA%/cmux/secrets.json.
-/// Each stored value is the Base64 encoding of: HMAC(32 bytes) || DPAPI ciphertext.
+/// DPAPI provides both confidentiality and integrity — no separate MAC is needed.
 /// </summary>
 public static class SecretStoreService
 {
@@ -38,28 +38,33 @@ public static class SecretStoreService
 
             var blob = Convert.FromBase64String(encoded);
 
-            // Try new format first: HMAC(32) || ciphertext
+            // Try current format: DPAPI with entropy
+            try
+            {
+                var plain = ProtectedData.Unprotect(blob, Entropy, DataProtectionScope.CurrentUser);
+                return Encoding.UTF8.GetString(plain);
+            }
+            catch (CryptographicException)
+            {
+                // Fall through to legacy formats
+            }
+
+            // Try previous format: HMAC(32) || ciphertext (strip the HMAC prefix)
             if (blob.Length > 32)
             {
                 try
                 {
-                    var storedHmac = blob[..32];
                     var ciphertext = blob[32..];
-
                     var plain = ProtectedData.Unprotect(ciphertext, Entropy, DataProtectionScope.CurrentUser);
-
-                    // Verify integrity
-                    var computedHmac = ComputeHmac(ciphertext);
-                    if (CryptographicOperations.FixedTimeEquals(storedHmac, computedHmac))
-                        return Encoding.UTF8.GetString(plain);
+                    return Encoding.UTF8.GetString(plain);
                 }
                 catch (CryptographicException)
                 {
-                    // New-format decryption failed — fall through to legacy
+                    // Fall through to oldest format
                 }
             }
 
-            // Fallback: legacy format without HMAC (no entropy)
+            // Oldest format: DPAPI without entropy
             var legacyPlain = ProtectedData.Unprotect(blob, optionalEntropy: null, DataProtectionScope.CurrentUser);
             return Encoding.UTF8.GetString(legacyPlain);
         }
@@ -86,14 +91,7 @@ public static class SecretStoreService
             {
                 var plain = Encoding.UTF8.GetBytes(value);
                 var ciphertext = ProtectedData.Protect(plain, Entropy, DataProtectionScope.CurrentUser);
-                var hmac = ComputeHmac(ciphertext);
-
-                // Store as HMAC || ciphertext
-                var blob = new byte[hmac.Length + ciphertext.Length];
-                hmac.CopyTo(blob, 0);
-                ciphertext.CopyTo(blob, hmac.Length);
-
-                map[secretName] = Convert.ToBase64String(blob);
+                map[secretName] = Convert.ToBase64String(ciphertext);
             }
 
             SaveRawSecrets(map);
@@ -102,12 +100,6 @@ public static class SecretStoreService
         {
             // Ignore secret persistence errors to avoid crashing the app.
         }
-    }
-
-    private static byte[] ComputeHmac(byte[] data)
-    {
-        using var hmac = new HMACSHA256(Entropy);
-        return hmac.ComputeHash(data);
     }
 
     public static void RemoveSecret(string secretName)

--- a/src/Cmux.Core/Services/SecretStoreService.cs
+++ b/src/Cmux.Core/Services/SecretStoreService.cs
@@ -38,20 +38,25 @@ public static class SecretStoreService
 
             var blob = Convert.FromBase64String(encoded);
 
-            // Try new format: HMAC(32) || ciphertext
+            // Try new format first: HMAC(32) || ciphertext
             if (blob.Length > 32)
             {
-                var storedHmac = blob[..32];
-                var ciphertext = blob[32..];
+                try
+                {
+                    var storedHmac = blob[..32];
+                    var ciphertext = blob[32..];
 
-                var plain = ProtectedData.Unprotect(ciphertext, Entropy, DataProtectionScope.CurrentUser);
+                    var plain = ProtectedData.Unprotect(ciphertext, Entropy, DataProtectionScope.CurrentUser);
 
-                // Verify integrity
-                var computedHmac = ComputeHmac(ciphertext);
-                if (!CryptographicOperations.FixedTimeEquals(storedHmac, computedHmac))
-                    return null; // Integrity check failed
-
-                return Encoding.UTF8.GetString(plain);
+                    // Verify integrity
+                    var computedHmac = ComputeHmac(ciphertext);
+                    if (CryptographicOperations.FixedTimeEquals(storedHmac, computedHmac))
+                        return Encoding.UTF8.GetString(plain);
+                }
+                catch (CryptographicException)
+                {
+                    // New-format decryption failed — fall through to legacy
+                }
             }
 
             // Fallback: legacy format without HMAC (no entropy)

--- a/src/Cmux.Core/Terminal/ConPtyInterop.cs
+++ b/src/Cmux.Core/Terminal/ConPtyInterop.cs
@@ -146,6 +146,24 @@ internal static partial class ConPtyInterop
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern uint WaitForMultipleObjects(
+        uint nCount,
+        IntPtr[] lpHandles,
+        [MarshalAs(UnmanagedType.Bool)] bool bWaitAll,
+        uint dwMilliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern IntPtr CreateEventW(
+        IntPtr lpEventAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool bManualReset,
+        [MarshalAs(UnmanagedType.Bool)] bool bInitialState,
+        IntPtr lpName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool SetEvent(IntPtr hEvent);
+
     internal const uint INFINITE = 0xFFFFFFFF;
     internal const uint WAIT_OBJECT_0 = 0x00000000;
 }

--- a/src/Cmux.Core/Terminal/ScrollbackBuffer.cs
+++ b/src/Cmux.Core/Terminal/ScrollbackBuffer.cs
@@ -10,8 +10,9 @@ public sealed class ScrollbackBuffer<T>
     private T[] _items;
     private int _head; // Index of the oldest item
     private int _count;
+    private readonly object _syncRoot = new();
 
-    public int Count => _count;
+    public int Count { get { lock (_syncRoot) return _count; } }
     public int Capacity => _items.Length;
 
     public ScrollbackBuffer(int capacity)
@@ -23,9 +24,12 @@ public sealed class ScrollbackBuffer<T>
     {
         get
         {
-            if (index < 0 || index >= _count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-            return _items[(_head + index) % _items.Length];
+            lock (_syncRoot)
+            {
+                if (index < 0 || index >= _count)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                return _items[(_head + index) % _items.Length];
+            }
         }
     }
 
@@ -34,17 +38,20 @@ public sealed class ScrollbackBuffer<T>
     /// </summary>
     public void Add(T item)
     {
-        int insertIndex = (_head + _count) % _items.Length;
-        _items[insertIndex] = item;
+        lock (_syncRoot)
+        {
+            int insertIndex = (_head + _count) % _items.Length;
+            _items[insertIndex] = item;
 
-        if (_count < _items.Length)
-        {
-            _count++;
-        }
-        else
-        {
-            // Buffer is full — advance head (oldest item is overwritten)
-            _head = (_head + 1) % _items.Length;
+            if (_count < _items.Length)
+            {
+                _count++;
+            }
+            else
+            {
+                // Buffer is full — advance head (oldest item is overwritten)
+                _head = (_head + 1) % _items.Length;
+            }
         }
     }
 
@@ -53,15 +60,29 @@ public sealed class ScrollbackBuffer<T>
     /// </summary>
     public void AddRange(IEnumerable<T> items)
     {
-        foreach (var item in items)
-            Add(item);
+        lock (_syncRoot)
+        {
+            foreach (var item in items)
+            {
+                int insertIndex = (_head + _count) % _items.Length;
+                _items[insertIndex] = item;
+
+                if (_count < _items.Length)
+                    _count++;
+                else
+                    _head = (_head + 1) % _items.Length;
+            }
+        }
     }
 
     public void Clear()
     {
-        Array.Clear(_items, 0, _items.Length);
-        _head = 0;
-        _count = 0;
+        lock (_syncRoot)
+        {
+            Array.Clear(_items, 0, _items.Length);
+            _head = 0;
+            _count = 0;
+        }
     }
 
     /// <summary>
@@ -69,9 +90,12 @@ public sealed class ScrollbackBuffer<T>
     /// </summary>
     public List<T> ToList()
     {
-        var result = new List<T>(_count);
-        for (int i = 0; i < _count; i++)
-            result.Add(_items[(_head + i) % _items.Length]);
-        return result;
+        lock (_syncRoot)
+        {
+            var result = new List<T>(_count);
+            for (int i = 0; i < _count; i++)
+                result.Add(_items[(_head + i) % _items.Length]);
+            return result;
+        }
     }
 }

--- a/src/Cmux.Core/Terminal/TerminalBuffer.cs
+++ b/src/Cmux.Core/Terminal/TerminalBuffer.cs
@@ -10,6 +10,10 @@ public class TerminalBuffer
     private TerminalCell[,] _cells;
     private readonly ScrollbackBuffer<TerminalCell[]> _scrollback;
     private readonly int _maxScrollback;
+    private readonly object _syncRoot = new();
+
+    /// <summary>Lock object for external callers that need to synchronize access.</summary>
+    public object SyncRoot => _syncRoot;
 
     public int Cols { get; private set; }
     public int Rows { get; private set; }
@@ -98,8 +102,11 @@ public class TerminalBuffer
 
     public TerminalCell[]? GetScrollbackLine(int index)
     {
-        if (index < 0 || index >= _scrollback.Count) return null;
-        return _scrollback[index];
+        lock (_syncRoot)
+        {
+            if (index < 0 || index >= _scrollback.Count) return null;
+            return _scrollback[index];
+        }
     }
 
     public void SetChar(int row, int col, char ch, TerminalAttribute attr)
@@ -555,20 +562,23 @@ public class TerminalBuffer
 
     public string ExportPlainText(int maxScrollbackLines = 20000)
     {
-        var lines = new List<string>();
+        lock (_syncRoot)
+        {
+            var lines = new List<string>();
 
-        int scrollbackStart = Math.Max(0, _scrollback.Count - Math.Max(0, maxScrollbackLines));
-        for (int i = scrollbackStart; i < _scrollback.Count; i++)
-            lines.Add(LineToText(_scrollback[i], Cols));
+            int scrollbackStart = Math.Max(0, _scrollback.Count - Math.Max(0, maxScrollbackLines));
+            for (int i = scrollbackStart; i < _scrollback.Count; i++)
+                lines.Add(LineToText(_scrollback[i], Cols));
 
-        for (int row = 0; row < Rows; row++)
-            lines.Add(LineToText(GetLine(row), Cols));
+            for (int row = 0; row < Rows; row++)
+                lines.Add(LineToText(GetLine(row), Cols));
 
-        int lastNonEmpty = lines.FindLastIndex(line => !string.IsNullOrWhiteSpace(line));
-        if (lastNonEmpty < 0)
-            return string.Empty;
+            int lastNonEmpty = lines.FindLastIndex(line => !string.IsNullOrWhiteSpace(line));
+            if (lastNonEmpty < 0)
+                return string.Empty;
 
-        return string.Join(Environment.NewLine, lines.Take(lastNonEmpty + 1));
+            return string.Join(Environment.NewLine, lines.Take(lastNonEmpty + 1));
+        }
     }
 
     /// <summary>
@@ -577,22 +587,25 @@ public class TerminalBuffer
     /// </summary>
     public TerminalBufferSnapshot CreateSnapshot(int maxScrollbackLines = 3000)
     {
-        var snapshot = new TerminalBufferSnapshot
+        lock (_syncRoot)
         {
-            Cols = Cols,
-            Rows = Rows,
-            CursorRow = CursorRow,
-            CursorCol = CursorCol,
-        };
+            var snapshot = new TerminalBufferSnapshot
+            {
+                Cols = Cols,
+                Rows = Rows,
+                CursorRow = CursorRow,
+                CursorCol = CursorCol,
+            };
 
-        int scrollbackStart = Math.Max(0, _scrollback.Count - Math.Max(0, maxScrollbackLines));
-        for (int i = scrollbackStart; i < _scrollback.Count; i++)
-            snapshot.ScrollbackLines.Add(LineToText(_scrollback[i], Cols));
+            int scrollbackStart = Math.Max(0, _scrollback.Count - Math.Max(0, maxScrollbackLines));
+            for (int i = scrollbackStart; i < _scrollback.Count; i++)
+                snapshot.ScrollbackLines.Add(LineToText(_scrollback[i], Cols));
 
-        for (int row = 0; row < Rows; row++)
-            snapshot.ScreenLines.Add(LineToText(GetLine(row), Cols));
+            for (int row = 0; row < Rows; row++)
+                snapshot.ScreenLines.Add(LineToText(GetLine(row), Cols));
 
-        return snapshot;
+            return snapshot;
+        }
     }
 
     /// <summary>
@@ -602,33 +615,36 @@ public class TerminalBuffer
     {
         if (snapshot == null) return;
 
-        _scrollback.Clear();
-        foreach (var line in snapshot.ScrollbackLines)
-            _scrollback.Add(TextToLine(line, Cols));
-
-        Clear();
-
-        int rowCount = Math.Min(Rows, snapshot.ScreenLines.Count);
-        for (int row = 0; row < rowCount; row++)
+        lock (_syncRoot)
         {
-            var text = snapshot.ScreenLines[row];
-            int colCount = Math.Min(Cols, text.Length);
-            for (int col = 0; col < colCount; col++)
-            {
-                _cells[row, col] = new TerminalCell
-                {
-                    Character = text[col],
-                    Attribute = TerminalAttribute.Default,
-                    IsDirty = true,
-                    Width = 1,
-                };
-            }
-        }
+            _scrollback.Clear();
+            foreach (var line in snapshot.ScrollbackLines)
+                _scrollback.Add(TextToLine(line, Cols));
 
-        CursorRow = Math.Clamp(snapshot.CursorRow, 0, Rows - 1);
-        CursorCol = Math.Clamp(snapshot.CursorCol, 0, Cols - 1);
-        ResetScrollRegion();
-        MarkAllDirty();
+            Clear();
+
+            int rowCount = Math.Min(Rows, snapshot.ScreenLines.Count);
+            for (int row = 0; row < rowCount; row++)
+            {
+                var text = snapshot.ScreenLines[row];
+                int colCount = Math.Min(Cols, text.Length);
+                for (int col = 0; col < colCount; col++)
+                {
+                    _cells[row, col] = new TerminalCell
+                    {
+                        Character = text[col],
+                        Attribute = TerminalAttribute.Default,
+                        IsDirty = true,
+                        Width = 1,
+                    };
+                }
+            }
+
+            CursorRow = Math.Clamp(snapshot.CursorRow, 0, Rows - 1);
+            CursorCol = Math.Clamp(snapshot.CursorCol, 0, Cols - 1);
+            ResetScrollRegion();
+            MarkAllDirty();
+        }
         RaiseContentChanged();
     }
 

--- a/src/Cmux.Core/Terminal/TerminalBuffer.cs
+++ b/src/Cmux.Core/Terminal/TerminalBuffer.cs
@@ -130,6 +130,8 @@ public class TerminalBuffer
         if (!ClampCursorToBounds())
             return;
 
+        int charWidth = UnicodeWidth.GetWidth(c);
+
         if (_wrapPending && AutoWrapMode)
         {
             CarriageReturn();
@@ -137,11 +139,23 @@ public class TerminalBuffer
             _wrapPending = false;
         }
 
+        // Wide character needs 2 columns — wrap early if it won't fit
+        if (charWidth == 2 && CursorCol + 1 >= Cols && AutoWrapMode)
+        {
+            // Fill the remaining single column with a space, then wrap
+            if (CursorCol < Cols)
+            {
+                _cells[CursorRow, CursorCol] = TerminalCell.Empty;
+            }
+            CarriageReturn();
+            LineFeed();
+        }
+
         if (InsertMode)
         {
-            // Shift characters right
-            for (int col = Cols - 1; col > CursorCol; col--)
-                _cells[CursorRow, col] = _cells[CursorRow, col - 1];
+            // Shift characters right by charWidth positions
+            for (int col = Cols - 1; col > CursorCol + charWidth - 1; col--)
+                _cells[CursorRow, col] = _cells[CursorRow, col - charWidth];
         }
 
         if (CursorRow >= 0 && CursorRow < Rows && CursorCol >= 0 && CursorCol < Cols)
@@ -151,17 +165,29 @@ public class TerminalBuffer
                 Character = c,
                 Attribute = CurrentAttribute,
                 IsDirty = true,
-                Width = 1,
+                Width = charWidth,
             };
+
+            // Wide char: place a padding cell in the next column
+            if (charWidth == 2 && CursorCol + 1 < Cols)
+            {
+                _cells[CursorRow, CursorCol + 1] = new TerminalCell
+                {
+                    Character = '\0',
+                    Attribute = CurrentAttribute,
+                    IsDirty = true,
+                    Width = 0, // padding cell for wide char
+                };
+            }
         }
 
-        if (CursorCol + 1 >= Cols)
+        if (CursorCol + charWidth >= Cols)
         {
             _wrapPending = true;
         }
         else
         {
-            CursorCol++;
+            CursorCol += charWidth;
         }
     }
 

--- a/src/Cmux.Core/Terminal/TerminalProcess.cs
+++ b/src/Cmux.Core/Terminal/TerminalProcess.cs
@@ -10,13 +10,14 @@ namespace Cmux.Core.Terminal;
 public sealed class TerminalProcess : IDisposable
 {
     private readonly PROCESS_INFORMATION _processInfo;
+    private readonly bool _processCreated;
     private IntPtr _attributeList;
     private IntPtr _cancelEvent;
     private bool _disposed;
     private readonly Thread _waitThread;
 
-    public int ProcessId => _processInfo.dwProcessId;
-    public IntPtr ProcessHandle => _processInfo.hProcess;
+    public int ProcessId => _processCreated ? _processInfo.dwProcessId : 0;
+    public IntPtr ProcessHandle => _processCreated ? _processInfo.hProcess : IntPtr.Zero;
 
     public event Action? Exited;
 
@@ -47,7 +48,18 @@ public sealed class TerminalProcess : IDisposable
             out _processInfo);
 
         if (!success)
+        {
+            // Clean up attribute list before throwing — _processInfo is uninitialized
+            if (_attributeList != IntPtr.Zero)
+            {
+                DeleteProcThreadAttributeList(_attributeList);
+                Marshal.FreeHGlobal(_attributeList);
+                _attributeList = IntPtr.Zero;
+            }
             throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create process with ConPTY.");
+        }
+
+        _processCreated = true;
 
         // Create a manual-reset event for signaling the wait thread to stop
         _cancelEvent = CreateEventW(IntPtr.Zero, bManualReset: true, bInitialState: false, IntPtr.Zero);
@@ -157,6 +169,7 @@ public sealed class TerminalProcess : IDisposable
     {
         get
         {
+            if (!_processCreated) return true;
             if (!GetExitCodeProcess(_processInfo.hProcess, out uint exitCode))
                 return true;
             return exitCode != STILL_ACTIVE;
@@ -165,7 +178,7 @@ public sealed class TerminalProcess : IDisposable
 
     public void Kill()
     {
-        if (!_disposed && !HasExited)
+        if (!_disposed && _processCreated && !HasExited)
         {
             TerminateProcess(_processInfo.hProcess, 1);
         }

--- a/src/Cmux.Core/Terminal/TerminalProcess.cs
+++ b/src/Cmux.Core/Terminal/TerminalProcess.cs
@@ -11,6 +11,7 @@ public sealed class TerminalProcess : IDisposable
 {
     private readonly PROCESS_INFORMATION _processInfo;
     private IntPtr _attributeList;
+    private IntPtr _cancelEvent;
     private bool _disposed;
     private readonly Thread _waitThread;
 
@@ -47,6 +48,9 @@ public sealed class TerminalProcess : IDisposable
 
         if (!success)
             throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create process with ConPTY.");
+
+        // Create a manual-reset event for signaling the wait thread to stop
+        _cancelEvent = CreateEventW(IntPtr.Zero, bManualReset: true, bInitialState: false, IntPtr.Zero);
 
         // Start a background thread to wait for process exit
         _waitThread = new Thread(WaitForExitThread)
@@ -137,8 +141,11 @@ public sealed class TerminalProcess : IDisposable
 
     private void WaitForExitThread()
     {
-        WaitForSingleObject(_processInfo.hProcess, INFINITE);
-        Exited?.Invoke();
+        var handles = new[] { _processInfo.hProcess, _cancelEvent };
+        uint result = WaitForMultipleObjects(2, handles, bWaitAll: false, INFINITE);
+        // WAIT_OBJECT_0 means process exited; WAIT_OBJECT_0+1 means cancel event signaled
+        if (result == WAIT_OBJECT_0)
+            Exited?.Invoke();
     }
 
     public void WaitForExit()
@@ -171,10 +178,20 @@ public sealed class TerminalProcess : IDisposable
 
         Kill();
 
+        // Signal the cancel event so the wait thread wakes up, then join it
+        if (_cancelEvent != IntPtr.Zero)
+            SetEvent(_cancelEvent);
+        _waitThread.Join(TimeSpan.FromSeconds(3));
+
         if (_processInfo.hProcess != IntPtr.Zero)
             CloseHandle(_processInfo.hProcess);
         if (_processInfo.hThread != IntPtr.Zero)
             CloseHandle(_processInfo.hThread);
+        if (_cancelEvent != IntPtr.Zero)
+        {
+            CloseHandle(_cancelEvent);
+            _cancelEvent = IntPtr.Zero;
+        }
 
         if (_attributeList != IntPtr.Zero)
         {

--- a/src/Cmux.Core/Terminal/TerminalProcess.cs
+++ b/src/Cmux.Core/Terminal/TerminalProcess.cs
@@ -63,6 +63,8 @@ public sealed class TerminalProcess : IDisposable
 
         // Create a manual-reset event for signaling the wait thread to stop
         _cancelEvent = CreateEventW(IntPtr.Zero, bManualReset: true, bInitialState: false, IntPtr.Zero);
+        if (_cancelEvent == IntPtr.Zero)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateEventW failed.");
 
         // Start a background thread to wait for process exit
         _waitThread = new Thread(WaitForExitThread)
@@ -157,7 +159,14 @@ public sealed class TerminalProcess : IDisposable
         uint result = WaitForMultipleObjects(2, handles, bWaitAll: false, INFINITE);
         // WAIT_OBJECT_0 means process exited; WAIT_OBJECT_0+1 means cancel event signaled
         if (result == WAIT_OBJECT_0)
+        {
             Exited?.Invoke();
+        }
+        else if (result == 0xFFFFFFFF) // WAIT_FAILED
+        {
+            // Invalid handle or other failure — treat as exited to avoid silent hang
+            Exited?.Invoke();
+        }
     }
 
     public void WaitForExit()

--- a/src/Cmux.Core/Terminal/TerminalSelection.cs
+++ b/src/Cmux.Core/Terminal/TerminalSelection.cs
@@ -23,31 +23,41 @@ public class TerminalSelection
 {
     private SelectionPoint? _start;
     private SelectionPoint? _end;
+    private readonly object _syncRoot = new();
 
-    public bool HasSelection => _start.HasValue && _end.HasValue;
-    public SelectionPoint? Start => _start;
-    public SelectionPoint? End => _end;
+    public bool HasSelection { get { lock (_syncRoot) return _start.HasValue && _end.HasValue; } }
+    public SelectionPoint? Start { get { lock (_syncRoot) return _start; } }
+    public SelectionPoint? End { get { lock (_syncRoot) return _end; } }
 
     public event Action? SelectionChanged;
 
     public void StartSelection(int row, int col)
     {
-        _start = new SelectionPoint(row, col);
-        _end = new SelectionPoint(row, col);
+        lock (_syncRoot)
+        {
+            _start = new SelectionPoint(row, col);
+            _end = new SelectionPoint(row, col);
+        }
         SelectionChanged?.Invoke();
     }
 
     public void ExtendSelection(int row, int col)
     {
-        if (!_start.HasValue) return;
-        _end = new SelectionPoint(row, col);
+        lock (_syncRoot)
+        {
+            if (!_start.HasValue) return;
+            _end = new SelectionPoint(row, col);
+        }
         SelectionChanged?.Invoke();
     }
 
     public void ClearSelection()
     {
-        _start = null;
-        _end = null;
+        lock (_syncRoot)
+        {
+            _start = null;
+            _end = null;
+        }
         SelectionChanged?.Invoke();
     }
 
@@ -56,15 +66,18 @@ public class TerminalSelection
     /// </summary>
     public (SelectionPoint start, SelectionPoint end)? GetNormalizedRange()
     {
-        if (!_start.HasValue || !_end.HasValue) return null;
+        lock (_syncRoot)
+        {
+            if (!_start.HasValue || !_end.HasValue) return null;
 
-        var s = _start.Value;
-        var e = _end.Value;
+            var s = _start.Value;
+            var e = _end.Value;
 
-        if (s.Row > e.Row || (s.Row == e.Row && s.Col > e.Col))
-            (s, e) = (e, s);
+            if (s.Row > e.Row || (s.Row == e.Row && s.Col > e.Col))
+                (s, e) = (e, s);
 
-        return (s, e);
+            return (s, e);
+        }
     }
 
     /// <summary>
@@ -167,8 +180,11 @@ public class TerminalSelection
 
         if (!IsWordChar(GetChar(col)))
         {
-            _start = new SelectionPoint(row, col);
-            _end = new SelectionPoint(row, col);
+            lock (_syncRoot)
+            {
+                _start = new SelectionPoint(row, col);
+                _end = new SelectionPoint(row, col);
+            }
             SelectionChanged?.Invoke();
             return;
         }
@@ -182,8 +198,11 @@ public class TerminalSelection
         while (endCol < buffer.Cols - 1 && IsWordChar(GetChar(endCol + 1)))
             endCol++;
 
-        _start = new SelectionPoint(row, startCol);
-        _end = new SelectionPoint(row, endCol);
+        lock (_syncRoot)
+        {
+            _start = new SelectionPoint(row, startCol);
+            _end = new SelectionPoint(row, endCol);
+        }
         SelectionChanged?.Invoke();
     }
 
@@ -192,8 +211,11 @@ public class TerminalSelection
     /// </summary>
     public void SelectLine(int row, int cols)
     {
-        _start = new SelectionPoint(row, 0);
-        _end = new SelectionPoint(row, cols - 1);
+        lock (_syncRoot)
+        {
+            _start = new SelectionPoint(row, 0);
+            _end = new SelectionPoint(row, cols - 1);
+        }
         SelectionChanged?.Invoke();
     }
 
@@ -202,8 +224,11 @@ public class TerminalSelection
     /// </summary>
     public void SelectAll(int rows, int cols)
     {
-        _start = new SelectionPoint(0, 0);
-        _end = new SelectionPoint(rows - 1, cols - 1);
+        lock (_syncRoot)
+        {
+            _start = new SelectionPoint(0, 0);
+            _end = new SelectionPoint(rows - 1, cols - 1);
+        }
         SelectionChanged?.Invoke();
     }
 }

--- a/src/Cmux.Core/Terminal/TerminalSession.cs
+++ b/src/Cmux.Core/Terminal/TerminalSession.cs
@@ -19,6 +19,7 @@ public sealed class TerminalSession : IDisposable
     private FileStream? _readStream;
     private FileStream? _writeStream;
     private Thread? _readThread;
+    private CancellationTokenSource? _readCts;
     private volatile bool _disposed;
     private volatile bool _daemonWriteLogged;
     private volatile bool _localWriteNullLogged;
@@ -172,6 +173,7 @@ public sealed class TerminalSession : IDisposable
                 ProcessExited?.Invoke();
             };
 
+            _readCts = new CancellationTokenSource();
             _readThread = new Thread(ReadLoop)
             {
                 IsBackground = true,
@@ -187,11 +189,19 @@ public sealed class TerminalSession : IDisposable
     private void ReadLoop()
     {
         var buffer = new byte[4096];
+        var ct = _readCts!.Token;
         try
         {
-            while (!_disposed && _readStream != null)
+            while (!ct.IsCancellationRequested)
             {
-                int bytesRead = _readStream.Read(buffer, 0, buffer.Length);
+                FileStream? stream;
+                lock (_lock)
+                {
+                    stream = _readStream;
+                }
+                if (stream == null) break;
+
+                int bytesRead = stream.Read(buffer, 0, buffer.Length);
                 if (bytesRead == 0) break;
 
                 var chunk = buffer.AsSpan(0, bytesRead).ToArray();
@@ -639,9 +649,23 @@ public sealed class TerminalSession : IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        _readStream?.Dispose();
-        _writeStream?.Dispose();
+        // Signal the read loop to stop
+        try { _readCts?.Cancel(); } catch { }
+
+        // Dispose streams to unblock any pending Read call
+        lock (_lock)
+        {
+            _readStream?.Dispose();
+            _readStream = null;
+            _writeStream?.Dispose();
+            _writeStream = null;
+        }
+
+        // Wait for the read thread to finish
+        _readThread?.Join(TimeSpan.FromSeconds(2));
+
         _process?.Dispose();
         _console?.Dispose();
+        _readCts?.Dispose();
     }
 }

--- a/src/Cmux.Core/Terminal/TerminalSession.cs
+++ b/src/Cmux.Core/Terminal/TerminalSession.cs
@@ -689,14 +689,29 @@ public sealed class TerminalSession : IDisposable
         _readCts?.Dispose();
     }
 
+    private static readonly bool _diagEnabled =
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CMUX_DIAG"));
+
     private static readonly string _diagLogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "cmux-diag.log");
 
+    private const long MaxDiagLogSize = 2 * 1024 * 1024; // 2 MB
+
     private static void DiagLog(string msg)
     {
+        if (!_diagEnabled) return;
         try
         {
+            // Rotate when the log exceeds the size limit
+            var fi = new FileInfo(_diagLogPath);
+            if (fi.Exists && fi.Length > MaxDiagLogSize)
+            {
+                var rotated = _diagLogPath + ".old";
+                File.Delete(rotated);
+                File.Move(_diagLogPath, rotated);
+            }
+
             File.AppendAllText(_diagLogPath, $"{DateTime.Now:HH:mm:ss.fff} {msg}\n");
         }
         catch { /* ignore */ }

--- a/src/Cmux.Core/Terminal/TerminalSession.cs
+++ b/src/Cmux.Core/Terminal/TerminalSession.cs
@@ -160,10 +160,21 @@ public sealed class TerminalSession : IDisposable
 
         WorkingDirectory = effectiveWorkingDirectory;
 
+        DiagLog($"[TerminalSession:{PaneId}] Start: cols={Buffer.Cols} rows={Buffer.Rows} cmd={command} cwd={effectiveWorkingDirectory}");
         lock (_lock)
         {
-            _console = PseudoConsole.Create((short)Buffer.Cols, (short)Buffer.Rows);
-            _process = new TerminalProcess(_console, command, effectiveWorkingDirectory);
+            try
+            {
+                _console = PseudoConsole.Create((short)Buffer.Cols, (short)Buffer.Rows);
+                DiagLog($"[TerminalSession:{PaneId}] PseudoConsole created, ReadPipe={_console.ReadPipe.DangerousGetHandle()}, WritePipe={_console.WritePipe.DangerousGetHandle()}");
+                _process = new TerminalProcess(_console, command, effectiveWorkingDirectory);
+                DiagLog($"[TerminalSession:{PaneId}] TerminalProcess created, PID={_process.ProcessId}");
+            }
+            catch (Exception ex)
+            {
+                DiagLog($"[TerminalSession:{PaneId}] Start FAILED: {ex}");
+                throw;
+            }
 
             _readStream = new FileStream(_console.ReadPipe, FileAccess.Read);
             _writeStream = new FileStream(_console.WritePipe, FileAccess.Write);
@@ -190,6 +201,7 @@ public sealed class TerminalSession : IDisposable
     {
         var buffer = new byte[4096];
         var ct = _readCts!.Token;
+        DiagLog($"[TerminalSession:{PaneId}] ReadLoop started");
         try
         {
             while (!ct.IsCancellationRequested)
@@ -199,10 +211,10 @@ public sealed class TerminalSession : IDisposable
                 {
                     stream = _readStream;
                 }
-                if (stream == null) break;
+                if (stream == null) { DiagLog($"[TerminalSession:{PaneId}] ReadLoop: stream is null, exiting"); break; }
 
                 int bytesRead = stream.Read(buffer, 0, buffer.Length);
-                if (bytesRead == 0) break;
+                if (bytesRead == 0) { DiagLog($"[TerminalSession:{PaneId}] ReadLoop: EOF, exiting"); break; }
 
                 var chunk = buffer.AsSpan(0, bytesRead).ToArray();
 
@@ -224,13 +236,21 @@ public sealed class TerminalSession : IDisposable
                 Redraw?.Invoke();
             }
         }
-        catch (IOException) when (_disposed)
+        catch (IOException ex) when (_disposed)
         {
-            // Expected on shutdown
+            DiagLog($"[TerminalSession:{PaneId}] ReadLoop: IOException on shutdown: {ex.Message}");
         }
-        catch (ObjectDisposedException)
+        catch (IOException ex)
         {
-            // Expected on shutdown
+            DiagLog($"[TerminalSession:{PaneId}] ReadLoop: IOException during operation: {ex}");
+        }
+        catch (ObjectDisposedException ex)
+        {
+            DiagLog($"[TerminalSession:{PaneId}] ReadLoop: ObjectDisposedException: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            DiagLog($"[TerminalSession:{PaneId}] ReadLoop: Unexpected exception: {ex}");
         }
     }
 
@@ -667,5 +687,18 @@ public sealed class TerminalSession : IDisposable
         _process?.Dispose();
         _console?.Dispose();
         _readCts?.Dispose();
+    }
+
+    private static readonly string _diagLogPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "cmux-diag.log");
+
+    private static void DiagLog(string msg)
+    {
+        try
+        {
+            File.AppendAllText(_diagLogPath, $"{DateTime.Now:HH:mm:ss.fff} {msg}\n");
+        }
+        catch { /* ignore */ }
     }
 }

--- a/src/Cmux.Core/Terminal/UnicodeWidth.cs
+++ b/src/Cmux.Core/Terminal/UnicodeWidth.cs
@@ -1,0 +1,77 @@
+namespace Cmux.Core.Terminal;
+
+/// <summary>
+/// Provides Unicode character width calculation (wcwidth equivalent).
+/// Full-width CJK characters return 2; most others return 1.
+/// </summary>
+public static class UnicodeWidth
+{
+    /// <summary>
+    /// Returns the column width of a character: 2 for full-width / wide, 1 otherwise.
+    /// </summary>
+    public static int GetWidth(char c)
+    {
+        int cp = c;
+        return IsWide(cp) ? 2 : 1;
+    }
+
+    /// <summary>
+    /// Returns true if the codepoint occupies two terminal columns.
+    /// Covers CJK Unified Ideographs, Hangul, Katakana/Hiragana, fullwidth forms, etc.
+    /// Based on Unicode East Asian Width property (W and F categories).
+    /// </summary>
+    private static bool IsWide(int cp)
+    {
+        // Fullwidth Forms (FF01-FF60, FFE0-FFE6)
+        if (cp >= 0xFF01 && cp <= 0xFF60) return true;
+        if (cp >= 0xFFE0 && cp <= 0xFFE6) return true;
+
+        // CJK Radicals Supplement (2E80-2EFF)
+        if (cp >= 0x2E80 && cp <= 0x2EFF) return true;
+        // Kangxi Radicals (2F00-2FDF)
+        if (cp >= 0x2F00 && cp <= 0x2FDF) return true;
+        // Ideographic Description Characters (2FF0-2FFF)
+        if (cp >= 0x2FF0 && cp <= 0x2FFF) return true;
+
+        // CJK Symbols and Punctuation (3000-303F)
+        if (cp >= 0x3000 && cp <= 0x303F) return true;
+        // Hiragana (3040-309F)
+        if (cp >= 0x3040 && cp <= 0x309F) return true;
+        // Katakana (30A0-30FF)
+        if (cp >= 0x30A0 && cp <= 0x30FF) return true;
+        // Bopomofo (3100-312F)
+        if (cp >= 0x3100 && cp <= 0x312F) return true;
+        // Hangul Compatibility Jamo (3130-318F)
+        if (cp >= 0x3130 && cp <= 0x318F) return true;
+        // Kanbun (3190-319F)
+        if (cp >= 0x3190 && cp <= 0x319F) return true;
+        // Bopomofo Extended (31A0-31BF)
+        if (cp >= 0x31A0 && cp <= 0x31BF) return true;
+        // CJK Strokes (31C0-31EF)
+        if (cp >= 0x31C0 && cp <= 0x31EF) return true;
+        // Katakana Phonetic Extensions (31F0-31FF)
+        if (cp >= 0x31F0 && cp <= 0x31FF) return true;
+        // Enclosed CJK Letters and Months (3200-32FF)
+        if (cp >= 0x3200 && cp <= 0x32FF) return true;
+        // CJK Compatibility (3300-33FF)
+        if (cp >= 0x3300 && cp <= 0x33FF) return true;
+        // CJK Unified Ideographs Extension A (3400-4DBF)
+        if (cp >= 0x3400 && cp <= 0x4DBF) return true;
+        // CJK Unified Ideographs (4E00-9FFF)
+        if (cp >= 0x4E00 && cp <= 0x9FFF) return true;
+
+        // Yi Syllables and Radicals (A000-A4CF)
+        if (cp >= 0xA000 && cp <= 0xA4CF) return true;
+
+        // Hangul Syllables (AC00-D7AF)
+        if (cp >= 0xAC00 && cp <= 0xD7AF) return true;
+
+        // CJK Compatibility Ideographs (F900-FAFF)
+        if (cp >= 0xF900 && cp <= 0xFAFF) return true;
+
+        // CJK Compatibility Forms (FE30-FE4F)
+        if (cp >= 0xFE30 && cp <= 0xFE4F) return true;
+
+        return false;
+    }
+}

--- a/src/Cmux.Core/Terminal/VtParser.cs
+++ b/src/Cmux.Core/Terminal/VtParser.cs
@@ -39,6 +39,7 @@ public class VtParser
     private readonly StringBuilder _oscString = new();
     private readonly List<int> _csiParams = [];
     private byte _collectChar;
+    private bool _oscOverflow;
 
     // UTF-8 decoder state
     private int _utf8Remaining;
@@ -354,23 +355,27 @@ public class VtParser
     {
         if (b == 0x07) // BEL terminates OSC
         {
-            OnOscDispatch?.Invoke(_oscString.ToString());
+            if (!_oscOverflow)
+                OnOscDispatch?.Invoke(_oscString.ToString());
+            _oscOverflow = false;
             _state = State.Ground;
             return;
         }
 
         if (b == 0x9C) // ST (8-bit)
         {
-            OnOscDispatch?.Invoke(_oscString.ToString());
+            if (!_oscOverflow)
+                OnOscDispatch?.Invoke(_oscString.ToString());
+            _oscOverflow = false;
             _state = State.Ground;
             return;
         }
 
         if (b == 0x1B) // Possible ST (ESC \)
         {
-            // Will be handled on next byte — peek ahead not needed,
-            // the ESC handler will fire. But we need to dispatch first.
-            OnOscDispatch?.Invoke(_oscString.ToString());
+            if (!_oscOverflow)
+                OnOscDispatch?.Invoke(_oscString.ToString());
+            _oscOverflow = false;
             _state = State.Escape;
             return;
         }
@@ -383,10 +388,8 @@ public class VtParser
             {
                 // OSC too long — stay in OscString state to consume remaining
                 // bytes until the terminator (BEL/ST), but stop accumulating.
-                // The dispatch will be skipped since we clear the buffer.
                 _oscString.Clear();
-                // Remain in OscString — the terminator checks above will
-                // transition to Ground when BEL/ST arrives.
+                _oscOverflow = true;
             }
         }
     }

--- a/src/Cmux.Core/Terminal/VtParser.cs
+++ b/src/Cmux.Core/Terminal/VtParser.cs
@@ -381,9 +381,12 @@ public class VtParser
                 _oscString.Append((char)b);
             else
             {
-                // OSC too long — abort to prevent OOM
+                // OSC too long — stay in OscString state to consume remaining
+                // bytes until the terminator (BEL/ST), but stop accumulating.
+                // The dispatch will be skipped since we clear the buffer.
                 _oscString.Clear();
-                _state = State.Ground;
+                // Remain in OscString — the terminator checks above will
+                // transition to Ground when BEL/ST arrives.
             }
         }
     }

--- a/src/Cmux.Core/Terminal/VtParser.cs
+++ b/src/Cmux.Core/Terminal/VtParser.cs
@@ -30,6 +30,9 @@ public class VtParser
         SosPmApc,
     }
 
+    private const int MaxOscLength = 65536;   // 64 KB
+    private const int MaxCsiParams = 256;
+
     private State _state = State.Ground;
     private readonly StringBuilder _params = new();
     private readonly StringBuilder _intermediates = new();
@@ -294,7 +297,9 @@ public class VtParser
     {
         if (b is >= 0x30 and <= 0x39 or (byte)';' or (byte)':')
         {
-            _params.Append((char)b);
+            // Limit raw param string length to prevent unbounded growth
+            if (_params.Length < MaxCsiParams * 12)
+                _params.Append((char)b);
             return;
         }
 
@@ -372,7 +377,14 @@ public class VtParser
 
         if (b >= 0x20 || b == 0x09) // Printable or tab
         {
-            _oscString.Append((char)b);
+            if (_oscString.Length < MaxOscLength)
+                _oscString.Append((char)b);
+            else
+            {
+                // OSC too long — abort to prevent OOM
+                _oscString.Clear();
+                _state = State.Ground;
+            }
         }
     }
 
@@ -398,6 +410,9 @@ public class VtParser
         var paramStr = _params.ToString();
         foreach (var part in paramStr.Split(';'))
         {
+            if (_csiParams.Count >= MaxCsiParams)
+                break;
+
             if (int.TryParse(part, out int val))
                 _csiParams.Add(val);
             else

--- a/src/Cmux/Controls/TerminalControl.cs
+++ b/src/Cmux/Controls/TerminalControl.cs
@@ -418,6 +418,7 @@ public class TerminalControl : FrameworkElement
 
                 // Text run state for batching
                 int runStartCol = -1;
+                int runColSpan = 0;
                 Color runFgColor = default;
                 bool runBold = false, runItalic = false, runDim = false;
                 bool runUnderline = false, runStrikethrough = false;
@@ -462,20 +463,21 @@ public class TerminalControl : FrameworkElement
                     if (isSelected && _theme.SelectionBackground.HasValue)
                         cellBg = _theme.SelectionBackground.Value;
 
-                    // Draw cell background
+                    // Draw cell background (double width for wide chars)
+                    double drawWidth = cell.Width >= 2 ? _cellWidth * 2 : _cellWidth;
                     if (!cellBg.IsDefault)
                     {
                         dc.DrawRectangle(GetCachedBrush(ToWpfColor(cellBg)), null,
-                            new Rect(x, y, _cellWidth, _cellHeight));
+                            new Rect(x, y, drawWidth, _cellHeight));
                     }
 
                     // Search match highlight (behind text)
                     bool isSearchMatch = searchMatchSet.Contains((visRow, c));
                     bool isCurrentMatch = currentMatchSet.Contains((visRow, c));
                     if (isCurrentMatch)
-                        dc.DrawRectangle(currentMatchBrush, null, new Rect(x, y, _cellWidth, _cellHeight));
+                        dc.DrawRectangle(currentMatchBrush, null, new Rect(x, y, drawWidth, _cellHeight));
                     else if (isSearchMatch)
-                        dc.DrawRectangle(searchMatchBrush, null, new Rect(x, y, _cellWidth, _cellHeight));
+                        dc.DrawRectangle(searchMatchBrush, null, new Rect(x, y, drawWidth, _cellHeight));
 
                     // URL hover highlight
                     if (_hoveredUrl is { } url && visRow == url.row && c >= url.startCol && c <= url.endCol)
@@ -483,6 +485,12 @@ public class TerminalControl : FrameworkElement
                         var urlPen = new Pen(GetCachedBrush(Color.FromRgb(0x81, 0x8C, 0xF8)), 1);
                         urlPen.Freeze();
                         dc.DrawLine(urlPen, new Point(x, y + _cellHeight - 1), new Point(x + _cellWidth, y + _cellHeight - 1));
+                    }
+
+                    // Skip padding cells placed by wide characters
+                    if (cell.Width == 0 && cell.Character == '\0')
+                    {
+                        continue;
                     }
 
                     // Text batching: group consecutive characters with same visual style
@@ -501,14 +509,16 @@ public class TerminalControl : FrameworkElement
                             italic != runItalic || dim != runDim ||
                             underline != runUnderline || strikethrough != runStrikethrough))
                         {
-                            FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
+                            FlushTextRun(dc, dpi, y, runStartCol, runColSpan, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
                             runStartCol = -1;
+                            runColSpan = 0;
                         }
 
                         // Start new run or continue existing
                         if (runStartCol < 0)
                         {
                             runStartCol = c;
+                            runColSpan = 0;
                             runFgColor = fgColor;
                             runBold = bold;
                             runItalic = italic;
@@ -519,18 +529,20 @@ public class TerminalControl : FrameworkElement
                         }
 
                         _textRunBuffer.Append(cell.Character);
+                        runColSpan += cell.Width >= 2 ? 2 : 1;
                     }
                     else if (runStartCol >= 0)
                     {
                         // Empty cell — flush the current run
-                        FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
+                        FlushTextRun(dc, dpi, y, runStartCol, runColSpan, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
                         runStartCol = -1;
+                        runColSpan = 0;
                     }
                 }
 
                 // Flush final run for this row
                 if (runStartCol >= 0)
-                    FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
+                    FlushTextRun(dc, dpi, y, runStartCol, runColSpan, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
             }
 
             // Cursor (only when viewing live buffer)
@@ -588,7 +600,7 @@ public class TerminalControl : FrameworkElement
     /// <summary>
     /// Draws a batched text run and its decorations (underline/strikethrough).
     /// </summary>
-    private void FlushTextRun(DrawingContext dc, double dpi, double y, int startCol,
+    private void FlushTextRun(DrawingContext dc, double dpi, double y, int startCol, int colSpan,
         Color fgColor, bool bold, bool italic, bool dim, bool underline, bool strikethrough)
     {
         if (_textRunBuffer.Length == 0) return;
@@ -609,7 +621,7 @@ public class TerminalControl : FrameworkElement
         double x = startCol * _cellWidth;
         dc.DrawText(text, new Point(x, y));
 
-        double runWidth = _textRunBuffer.Length * _cellWidth;
+        double runWidth = colSpan * _cellWidth;
 
         if (underline)
         {

--- a/src/Cmux/Controls/TerminalControl.cs
+++ b/src/Cmux/Controls/TerminalControl.cs
@@ -392,6 +392,10 @@ public class TerminalControl : FrameworkElement
                 dc.DrawRectangle(null, focusPen, new Rect(0, 0, ActualWidth, ActualHeight));
             }
 
+            // Lock buffer to prevent torn reads from background mutations
+            lock (buffer.SyncRoot)
+            {
+
             // Calculate scrollback offset
             int scrollbackCount = buffer.ScrollbackCount;
             bool isScrolledBack = _scrollOffset < 0;
@@ -590,6 +594,8 @@ public class TerminalControl : FrameworkElement
                     new Rect(ix, 6, iw, ih), 4, 4);
                 dc.DrawText(indicatorText, new Point(ix + 6, 8));
             }
+
+            } // lock (buffer.SyncRoot)
         }
         catch (Exception ex)
         {

--- a/src/Cmux/Services/AgentRuntimeService.cs
+++ b/src/Cmux/Services/AgentRuntimeService.cs
@@ -146,7 +146,7 @@ public sealed class AgentRuntimeService : IDisposable
         var cts = new CancellationTokenSource();
         _activeRuns[runKey] = cts;
 
-        _ = Task.Run(async () =>
+        var fireTask = Task.Run(async () =>
         {
             var assistantBuffer = new StringBuilder();
             try
@@ -271,6 +271,21 @@ public sealed class AgentRuntimeService : IDisposable
                 }
             }
         });
+
+        // Observe unhandled exceptions from the fire-and-forget task to prevent
+        // UnobservedTaskException and log any unexpected failures.
+        fireTask.ContinueWith(t =>
+        {
+            if (t.Exception != null)
+            {
+                Debug.WriteLine($"[AgentRuntimeService] Unhandled exception in agent run: {t.Exception.InnerException?.Message ?? t.Exception.Message}");
+                EmitUpdate(context, new AgentRuntimeUpdate
+                {
+                    Type = AgentRuntimeUpdateType.Error,
+                    Message = t.Exception.InnerException?.Message ?? t.Exception.Message,
+                });
+            }
+        }, TaskContinuationOptions.OnlyOnFaulted);
 
         return true;
     }

--- a/src/Cmux/ViewModels/WorkspaceViewModel.cs
+++ b/src/Cmux/ViewModels/WorkspaceViewModel.cs
@@ -102,6 +102,7 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
 
         int index = Surfaces.IndexOf(surface);
         surface.CaptureAllPaneTranscripts("surface-close");
+        surface.WorkingDirectoryChanged -= OnSurfaceWorkingDirectoryChanged;
         surface.Dispose();
         Surfaces.Remove(surface);
         Workspace.Surfaces.Remove(surface.Surface);
@@ -217,6 +218,9 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
     {
         _infoRefreshTimer?.Dispose();
         foreach (var surface in Surfaces)
+        {
+            surface.WorkingDirectoryChanged -= OnSurfaceWorkingDirectoryChanged;
             surface.Dispose();
+        }
     }
 }

--- a/src/Cmux/Views/MainWindow.xaml.cs
+++ b/src/Cmux/Views/MainWindow.xaml.cs
@@ -218,6 +218,7 @@ public partial class MainWindow : Window
     private void OnClosing(object sender, System.ComponentModel.CancelEventArgs e)
     {
         _uiRefreshTimer.Stop();
+        Cmux.Core.Config.SettingsService.SettingsChanged -= OnSettingsChanged;
         ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
         App.AgentRuntime.RuntimeUpdated -= OnAgentRuntimeUpdated;
         App.AgentConversationStore.StoreChanged -= OnAgentConversationStoreChanged;

--- a/tests/Cmux.Tests/Cmux.Tests.csproj
+++ b/tests/Cmux.Tests/Cmux.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cmux.Core\Cmux.Core.csproj" />
+    <ProjectReference Include="..\..\src\Cmux.Cli\Cmux.Cli.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Cmux.Tests/CoreTests.cs
+++ b/tests/Cmux.Tests/CoreTests.cs
@@ -962,9 +962,22 @@ public class VtParserLimitsTests
         sb.Append('\x07');
         parser.Feed(sb.ToString());
 
-        // The OSC should have been aborted due to exceeding the limit
-        if (receivedOsc != null)
-            receivedOsc.Length.Should().BeLessThan(70000);
+        // The OSC should NOT have been dispatched — overflow suppresses it entirely
+        receivedOsc.Should().BeNull("overflowed OSC sequences must not be dispatched");
+    }
+
+    [Fact]
+    public void Feed_OscWithinMaxLength_IsDispatched()
+    {
+        var parser = new VtParser();
+        string? receivedOsc = null;
+        parser.OnOscDispatch = osc => receivedOsc = osc;
+
+        var payload = new string('B', 1000);
+        parser.Feed($"\x1b]0;{payload}\x07");
+
+        receivedOsc.Should().NotBeNull();
+        receivedOsc.Should().Contain(payload);
     }
 
     [Fact]

--- a/tests/Cmux.Tests/CoreTests.cs
+++ b/tests/Cmux.Tests/CoreTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Cmux.Core.IPC;
 using Cmux.Core.Models;
 using Cmux.Core.Services;
 using Cmux.Core.Terminal;
@@ -758,5 +759,229 @@ public class AgentConversationStoreMessageParsingTests
             if (File.Exists(path))
                 File.Delete(path);
         }
+    }
+}
+
+public class CliParseArgsTests
+{
+    [Fact]
+    public void ParseArgs_LongOption_ParsesKeyValue()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["--title", "Hello"]);
+
+        result.Should().ContainKey("title");
+        result["title"].Should().Be("Hello");
+    }
+
+    [Fact]
+    public void ParseArgs_ShortOption_ParsesKeyValue()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["-t", "Hello"]);
+
+        result.Should().ContainKey("t");
+        result["t"].Should().Be("Hello");
+    }
+
+    [Fact]
+    public void ParseArgs_BooleanFlag_SetsTrue()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["--verbose"]);
+
+        result.Should().ContainKey("verbose");
+        result["verbose"].Should().Be("true");
+    }
+
+    [Fact]
+    public void ParseArgs_PositionalArgs_StoredWithPrefix()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["list", "workspace"]);
+
+        result.Should().ContainKey("_arg0");
+        result["_arg0"].Should().Be("list");
+        result.Should().ContainKey("_arg1");
+        result["_arg1"].Should().Be("workspace");
+    }
+
+    [Fact]
+    public void ParseArgs_MixedArgs_ParsedCorrectly()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["create", "--name", "My Workspace", "--icon", "star"]);
+
+        result["_arg0"].Should().Be("create");
+        result["name"].Should().Be("My Workspace");
+        result["icon"].Should().Be("star");
+    }
+
+    [Fact]
+    public void ParseArgs_Empty_ReturnsEmptyDictionary()
+    {
+        var result = Cmux.Cli.Program.ParseArgs([]);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseArgs_ShortBooleanFlag_SetsTrue()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["-v"]);
+
+        result.Should().ContainKey("v");
+        result["v"].Should().Be("true");
+    }
+
+    [Fact]
+    public void ParseArgs_MultipleLongOptions_AllParsed()
+    {
+        var result = Cmux.Cli.Program.ParseArgs(["--title", "Test", "--body", "Message body", "--subtitle", "Sub"]);
+
+        result["title"].Should().Be("Test");
+        result["body"].Should().Be("Message body");
+        result["subtitle"].Should().Be("Sub");
+    }
+}
+
+public class CliMainTests
+{
+    [Fact]
+    public async Task Main_NoArgs_ReturnsZero()
+    {
+        var result = await Cmux.Cli.Program.Main([]);
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Main_Help_ReturnsZero()
+    {
+        var result = await Cmux.Cli.Program.Main(["help"]);
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Main_Version_ReturnsZero()
+    {
+        var result = await Cmux.Cli.Program.Main(["version"]);
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Main_UnknownCommand_ReturnsOne()
+    {
+        var result = await Cmux.Cli.Program.Main(["nonexistent"]);
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Main_WorkspaceNoSubcommand_ReturnsOne()
+    {
+        var result = await Cmux.Cli.Program.Main(["workspace"]);
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Main_SurfaceNoSubcommand_ReturnsOne()
+    {
+        var result = await Cmux.Cli.Program.Main(["surface"]);
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Main_SplitNoDirection_ReturnsOne()
+    {
+        var result = await Cmux.Cli.Program.Main(["split"]);
+        result.Should().Be(1);
+    }
+}
+
+public class NamedPipeServerParseArgsTests
+{
+    [Fact]
+    public void ParseArgs_KeyValueFormat_ParsesCorrectly()
+    {
+        var args = new Dictionary<string, string>();
+        var method = typeof(NamedPipeServer).GetMethod("ParseArgs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        method!.Invoke(null, ["title=Hello body=World", args]);
+
+        args["title"].Should().Be("Hello");
+        args["body"].Should().Be("World");
+    }
+
+    [Fact]
+    public void ParseArgs_JsonFormat_ParsesCorrectly()
+    {
+        var args = new Dictionary<string, string>();
+        var method = typeof(NamedPipeServer).GetMethod("ParseArgs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        method!.Invoke(null, ["{\"title\":\"Hello\",\"body\":\"World\"}", args]);
+
+        args["title"].Should().Be("Hello");
+        args["body"].Should().Be("World");
+    }
+
+    [Fact]
+    public void ParseArgs_QuotedValues_ParsesCorrectly()
+    {
+        var args = new Dictionary<string, string>();
+        var method = typeof(NamedPipeServer).GetMethod("ParseArgs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        method!.Invoke(null, ["title=\"Hello World\" body='Test Value'", args]);
+
+        args["title"].Should().Be("Hello World");
+        args["body"].Should().Be("Test Value");
+    }
+
+    [Fact]
+    public void ParseArgs_PositionalArgs_StoredWithPrefix()
+    {
+        var args = new Dictionary<string, string>();
+        var method = typeof(NamedPipeServer).GetMethod("ParseArgs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        method!.Invoke(null, ["list workspace", args]);
+
+        args.Should().ContainKey("_arg0");
+        args["_arg0"].Should().Be("list");
+    }
+}
+
+public class VtParserLimitsTests
+{
+    [Fact]
+    public void Feed_OscExceedingMaxLength_AbortsSequence()
+    {
+        var parser = new VtParser();
+        string? receivedOsc = null;
+        parser.OnOscDispatch = osc => receivedOsc = osc;
+
+        // Start an OSC sequence and feed more than 64KB without terminating
+        var sb = new StringBuilder();
+        sb.Append("\x1b]0;");
+        sb.Append(new string('A', 70000));
+        sb.Append('\x07');
+        parser.Feed(sb.ToString());
+
+        // The OSC should have been aborted due to exceeding the limit
+        if (receivedOsc != null)
+            receivedOsc.Length.Should().BeLessThan(70000);
+    }
+
+    [Fact]
+    public void Feed_CsiWithManyParams_LimitsTo256()
+    {
+        var parser = new VtParser();
+        List<int>? receivedParams = null;
+        parser.OnCsiDispatch = (parameters, final, qualifier) =>
+        {
+            receivedParams = new List<int>(parameters);
+        };
+
+        // CSI with 300 parameters
+        var paramStr = string.Join(";", Enumerable.Range(1, 300));
+        parser.Feed($"\x1b[{paramStr}m");
+
+        receivedParams.Should().NotBeNull();
+        receivedParams!.Count.Should().BeLessOrEqualTo(256);
     }
 }


### PR DESCRIPTION
## Summary

Addresses all P0 (critical) and P1 (high priority) findings from code review, one commit per fix:

### P0 — Immediate fixes
- **Named Pipe ACL**: Restrict `\.\pipe\cmux` to current user via `PipeSecurity` / `NamedPipeServerStreamAcl.Create`
- **TerminalSession ReadLoop/Dispose race**: Introduce `CancellationTokenSource` and acquire `_readStream` under lock; join read thread on Dispose
- **TerminalProcess wait thread not joined**: Use `WaitForMultipleObjects` with a cancel event; signal + join on Dispose
- **VtParser OSC/CSI length limits**: Cap OSC at 64 KB, CSI params at 256 to prevent OOM from malicious streams
- **CLI test coverage**: Add 24 tests for ParseArgs, CLI commands, NamedPipeServer ParseArgs, and VtParser limits

### P1 — High priority fixes
- **Thread safety**: Add `lock` synchronization to `ScrollbackBuffer`, `TerminalSelection`, and `TerminalBuffer`
- **UI memory leaks**: Unsubscribe `SettingsChanged` in MainWindow; unsubscribe `WorkingDirectoryChanged` in WorkspaceViewModel
- **SecretStoreService integrity**: Add HMAC-SHA256 verification and DPAPI entropy; backward-compatible with legacy format
- **DaemonClient race**: Replace volatile check-then-act on `_pendingResponse` with a dedicated lock
- **TerminalProcess CreateProcess failure**: Add `_processCreated` guard on all property accessors; clean up on failure
- **AgentRuntimeService fire-and-forget**: Observe task exceptions via `ContinueWith(OnlyOnFaulted)` to prevent silent failures

### Additional fixes (from Codex review & testing)
- **SecretStore legacy fallback**: Fixed `blob.Length > 32` misclassifying legacy DPAPI secrets as new-format; now catches decryption failure and falls back to legacy `Unprotect(..., null, ...)` path
- **VtParser OSC overflow**: Fixed parser jumping to `Ground` state when OSC exceeds max length; now remains in `OscString` state to consume remaining bytes until BEL/ST terminator arrives
- **CJK/full-width character rendering**: Added `UnicodeWidth` utility for detecting wide characters (CJK, fullwidth forms, etc.); `TerminalBuffer.WriteChar` now advances cursor by 2 columns and places a padding cell for wide chars; `TerminalControl` rendering skips padding cells and draws wide characters at double width — fixes Chinese/Japanese/Korean text display where cursor position was offset

## Test plan
- [ ] Verify named pipe rejects connections from other users
- [ ] Verify terminal sessions start/stop cleanly without thread leaks
- [ ] Run new CLI and VtParser limit tests (`dotnet test`)
- [ ] Verify existing secrets still readable (legacy format fallback)
- [ ] Confirm daemon client request/response flow works under load
- [ ] Verify UI windows can be opened/closed repeatedly without memory growth
- [ ] Verify Chinese/Japanese/Korean characters display correctly with proper cursor alignment