### PR TITLE
fix: apply DefaultShell setting when starting terminal sessions

### DIFF
--- a/src/Cmux.Core/Models/PaneStateSnapshot.cs
+++ b/src/Cmux.Core/Models/PaneStateSnapshot.cs
@@ -6,6 +6,7 @@ public class PaneStateSnapshot
 {
     public DateTime CapturedAt { get; set; } = DateTime.UtcNow;
     public string? WorkingDirectory { get; set; }
+    public string? Shell { get; set; }
     public List<string> CommandHistory { get; set; } = [];
     public TerminalBufferSnapshot? BufferSnapshot { get; set; }
 }

--- a/src/Cmux.Core/Services/SessionPersistenceService.cs
+++ b/src/Cmux.Core/Services/SessionPersistenceService.cs
@@ -114,6 +114,7 @@ public class SessionPersistenceService
         {
             CapturedAt = source.CapturedAt,
             WorkingDirectory = source.WorkingDirectory,
+            Shell = source.Shell,
             CommandHistory = source.CommandHistory.ToList(),
             BufferSnapshot = source.BufferSnapshot == null
                 ? null

--- a/src/Cmux.Core/Services/ShellDetector.cs
+++ b/src/Cmux.Core/Services/ShellDetector.cs
@@ -1,0 +1,57 @@
+namespace Cmux.Core.Services;
+
+public record ShellInfo(string Name, string Path);
+
+public static class ShellDetector
+{
+    public static List<ShellInfo> DetectShells()
+    {
+        var shells = new List<ShellInfo>();
+
+        try
+        {
+            var pwshRoot = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PowerShell");
+            if (Directory.Exists(pwshRoot))
+            {
+                var pwshPaths = Directory.GetFiles(pwshRoot, "pwsh.exe", SearchOption.AllDirectories);
+                foreach (var path in pwshPaths.OrderByDescending(p => p))
+                    shells.Add(new ShellInfo("PowerShell 7", path));
+            }
+        } catch { /* ignore */ }
+
+        try
+        {
+            var system32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            var powershell = System.IO.Path.Combine(system32, "WindowsPowerShell", "v1.0", "powershell.exe");
+            if (File.Exists(powershell))
+                shells.Add(new ShellInfo("Windows PowerShell", powershell));
+
+            var cmd = System.IO.Path.Combine(system32, "cmd.exe");
+            if (File.Exists(cmd))
+                shells.Add(new ShellInfo("Command Prompt", cmd));
+
+            var wslPath = System.IO.Path.Combine(system32, "wsl.exe");
+            if (File.Exists(wslPath))
+                shells.Add(new ShellInfo("WSL", wslPath));
+        } catch { /* ignore */ }
+
+        try
+        {
+            var gitBashPaths = new[]
+            {
+                System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", "bin", "bash.exe"),
+                System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Git", "bin", "bash.exe"),
+            };
+            foreach (var path in gitBashPaths)
+            {
+                if (File.Exists(path))
+                {
+                    shells.Add(new ShellInfo("Git Bash", path));
+                    break;
+                }
+            }
+        } catch { /* ignore */ }
+
+        return shells;
+    }
+}

--- a/src/Cmux/ViewModels/MainViewModel.cs
+++ b/src/Cmux/ViewModels/MainViewModel.cs
@@ -128,6 +128,7 @@ public partial class MainViewModel : ObservableObject
                 {
                     CapturedAt = snapshot.CapturedAt,
                     WorkingDirectory = snapshot.WorkingDirectory,
+                    Shell = snapshot.Shell,
                     CommandHistory = snapshot.CommandHistory.ToList(),
                     BufferSnapshot = snapshot.BufferSnapshot == null
                         ? null
@@ -321,6 +322,7 @@ public partial class MainViewModel : ObservableObject
                         {
                             CapturedAt = kvp.Value.CapturedAt,
                             WorkingDirectory = kvp.Value.WorkingDirectory,
+                            Shell = kvp.Value.Shell,
                             CommandHistory = kvp.Value.CommandHistory.ToList(),
                             BufferSnapshot = kvp.Value.BufferSnapshot == null
                                 ? null

--- a/src/Cmux/ViewModels/SurfaceViewModel.cs
+++ b/src/Cmux/ViewModels/SurfaceViewModel.cs
@@ -17,6 +17,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
     private readonly NotificationService _notificationService;
     private readonly Dictionary<string, TerminalSession> _sessions = [];
     private readonly Dictionary<string, List<string>> _paneCommandHistory = [];
+    private readonly Dictionary<string, string?> _paneShells = [];
     private readonly HashSet<string> _daemonPanes = [];
     private readonly HashSet<string> _daemonOutputLogged = [];
     private static readonly object _daemonWaitLock = new();
@@ -80,7 +81,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
                         .ToList();
                 }
 
-                StartSession(leaf.PaneId, snapshot?.WorkingDirectory, snapshot);
+                StartSession(leaf.PaneId, snapshot?.WorkingDirectory, snapshot, snapshot?.Shell);
             }
         }
 
@@ -143,7 +144,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
 
             try
             {
-                session.Start(command: GetConfiguredShell(), workingDirectory: cwd);
+                session.Start(command: _paneShells.GetValueOrDefault(paneId) ?? GetConfiguredShell(), workingDirectory: cwd);
                 DaemonLog($"[DaemonDisconnected] {paneId} → local session started");
             }
             catch (Exception ex)
@@ -258,6 +259,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
 
             state.CapturedAt = DateTime.UtcNow;
             state.WorkingDirectory = session.WorkingDirectory;
+            state.Shell = _paneShells.GetValueOrDefault(paneId);
             state.BufferSnapshot = session.CreateBufferSnapshot(maxScrollbackLines: 3000);
 
             if (_paneCommandHistory.TryGetValue(paneId, out var history))
@@ -331,8 +333,12 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
             history.RemoveAt(0);
     }
 
-    private TerminalSession StartSession(string paneId, string? workingDirectory = null, PaneStateSnapshot? restoredState = null)
+    private TerminalSession StartSession(string paneId, string? workingDirectory = null, PaneStateSnapshot? restoredState = null, string? shell = null)
     {
+        var effectiveShell = shell ?? GetConfiguredShell();
+        // Store the explicit override (null = use default shell from settings)
+        _paneShells[paneId] = shell;
+
         // Wait for daemon connect task (includes starting daemon if needed).
         // First pane blocks up to 5s; subsequent panes get the cached result instantly.
         lock (_daemonWaitLock)
@@ -356,7 +362,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         {
             try
             {
-                return StartDaemonSession(paneId, workingDirectory, restoredState);
+                return StartDaemonSession(paneId, workingDirectory, restoredState, effectiveShell);
             }
             catch (Exception ex)
             {
@@ -365,12 +371,12 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         }
 
         DaemonLog($"[StartSession:{paneId}] Using LOCAL session");
-        return StartLocalSession(paneId, workingDirectory, restoredState);
+        return StartLocalSession(paneId, workingDirectory, restoredState, effectiveShell);
     }
 
     private static void DaemonLog(string message) => App.DaemonLog(message);
 
-    private TerminalSession StartDaemonSession(string paneId, string? workingDirectory, PaneStateSnapshot? restoredState)
+    private TerminalSession StartDaemonSession(string paneId, string? workingDirectory, PaneStateSnapshot? restoredState, string? shell)
     {
         // Use saved snapshot dimensions if available (avoids spurious resize on reconnect)
         var initCols = restoredState?.BufferSnapshot?.Cols ?? 120;
@@ -403,7 +409,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
                     _daemonPanes.Remove(paneId);
                     session.DaemonWrite = null;
                     session.DaemonResize = null;
-                    session.Start(command: GetConfiguredShell(), workingDirectory: effectiveCwd);
+                    session.Start(command: shell, workingDirectory: effectiveCwd);
                     return;
                 }
 
@@ -452,7 +458,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
                 _daemonPanes.Remove(paneId);
                 session.DaemonWrite = null;
                 session.DaemonResize = null;
-                session.Start(command: GetConfiguredShell(), workingDirectory: effectiveCwd);
+                session.Start(command: shell, workingDirectory: effectiveCwd);
             }
         });
 
@@ -468,13 +474,13 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         return string.IsNullOrWhiteSpace(shell) ? null : shell;
     }
 
-    private TerminalSession StartLocalSession(string paneId, string? workingDirectory, PaneStateSnapshot? restoredState)
+    private TerminalSession StartLocalSession(string paneId, string? workingDirectory, PaneStateSnapshot? restoredState, string? shell)
     {
         var session = new TerminalSession(paneId);
         WireSessionEvents(session, paneId);
 
         _sessions[paneId] = session;
-        session.Start(command: GetConfiguredShell(), workingDirectory: workingDirectory ?? restoredState?.WorkingDirectory);
+        session.Start(command: shell, workingDirectory: workingDirectory ?? restoredState?.WorkingDirectory);
 
         if (restoredState?.BufferSnapshot != null)
             session.RestoreBufferSnapshot(restoredState.BufferSnapshot);
@@ -529,7 +535,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         SplitFocused(SplitDirection.Horizontal);
     }
 
-    public void SplitFocused(SplitDirection direction)
+    public void SplitFocused(SplitDirection direction, string? shell = null)
     {
         if (FocusedPaneId == null) return;
 
@@ -541,12 +547,18 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         {
             var currentSession = GetSession(FocusedPaneId);
             var cwd = currentSession?.WorkingDirectory;
-            StartSession(newChild.PaneId, cwd);
+            var effectiveShell = shell ?? _paneShells.GetValueOrDefault(FocusedPaneId);
+            StartSession(newChild.PaneId, cwd, null, effectiveShell);
             FocusedPaneId = newChild.PaneId;
         }
 
         // Trigger UI update
         OnPropertyChanged(nameof(RootNode));
+    }
+
+    public void OpenPaneWithShell(string shellPath)
+    {
+        SplitFocused(SplitDirection.Vertical, shellPath);
     }
 
     [RelayCommand]
@@ -577,6 +589,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         Surface.PaneCustomNames.Remove(paneId);
         Surface.PaneSnapshots.Remove(paneId);
         _paneCommandHistory.Remove(paneId);
+        _paneShells.Remove(paneId);
 
         // If this is the only pane, don't remove it
         var leaves = RootNode.GetLeaves().ToList();
@@ -651,5 +664,6 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
             session.Dispose();
         _sessions.Clear();
         _daemonPanes.Clear();
+        _paneShells.Clear();
     }
 }

--- a/src/Cmux/ViewModels/SurfaceViewModel.cs
+++ b/src/Cmux/ViewModels/SurfaceViewModel.cs
@@ -143,7 +143,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
 
             try
             {
-                session.Start(workingDirectory: cwd);
+                session.Start(command: GetConfiguredShell(), workingDirectory: cwd);
                 DaemonLog($"[DaemonDisconnected] {paneId} → local session started");
             }
             catch (Exception ex)
@@ -403,7 +403,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
                     _daemonPanes.Remove(paneId);
                     session.DaemonWrite = null;
                     session.DaemonResize = null;
-                    session.Start(workingDirectory: effectiveCwd);
+                    session.Start(command: GetConfiguredShell(), workingDirectory: effectiveCwd);
                     return;
                 }
 
@@ -452,7 +452,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
                 _daemonPanes.Remove(paneId);
                 session.DaemonWrite = null;
                 session.DaemonResize = null;
-                session.Start(workingDirectory: effectiveCwd);
+                session.Start(command: GetConfiguredShell(), workingDirectory: effectiveCwd);
             }
         });
 
@@ -462,13 +462,19 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         return session;
     }
 
+    private static string? GetConfiguredShell()
+    {
+        var shell = SettingsService.Current.DefaultShell;
+        return string.IsNullOrWhiteSpace(shell) ? null : shell;
+    }
+
     private TerminalSession StartLocalSession(string paneId, string? workingDirectory, PaneStateSnapshot? restoredState)
     {
         var session = new TerminalSession(paneId);
         WireSessionEvents(session, paneId);
 
         _sessions[paneId] = session;
-        session.Start(workingDirectory: workingDirectory ?? restoredState?.WorkingDirectory);
+        session.Start(command: GetConfiguredShell(), workingDirectory: workingDirectory ?? restoredState?.WorkingDirectory);
 
         if (restoredState?.BufferSnapshot != null)
             session.RestoreBufferSnapshot(restoredState.BufferSnapshot);

--- a/src/Cmux/Views/MainWindow.xaml
+++ b/src/Cmux/Views/MainWindow.xaml
@@ -410,6 +410,14 @@
                                     Click="ToolbarSplitDown_Click">
                                 <TextBlock Text="&#xE74B;" FontFamily="Segoe MDL2 Assets" FontSize="12" />
                             </Button>
+                            <Button x:Name="ShellSelectorButton" Style="{StaticResource IconButton}"
+                                    ToolTip="Open pane with shell..."
+                                    Click="ShellSelector_Click">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="&#xE756;" FontFamily="Segoe MDL2 Assets" FontSize="12" />
+                                    <TextBlock Text="&#xE70D;" FontFamily="Segoe MDL2 Assets" FontSize="7" Margin="2,0,0,0" />
+                                </StackPanel>
+                            </Button>
                             <Rectangle Width="1" Height="16" Fill="{StaticResource BorderBrush}" Margin="4,0" />
                             <Button Style="{StaticResource IconButton}" ToolTip="Layout: 2 Columns"
                                     Click="ToolbarLayout2Col_Click">

--- a/src/Cmux/Views/MainWindow.xaml.cs
+++ b/src/Cmux/Views/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using Cmux.Controls;
+using Cmux.Core.Services;
 using Cmux.ViewModels;
 using Cmux.Services;
 
@@ -646,6 +647,27 @@ public partial class MainWindow : Window
     // Toolbar handlers
     private void ToolbarSplitRight_Click(object sender, RoutedEventArgs e) => ViewModel.SelectedWorkspace?.SelectedSurface?.SplitRight();
     private void ToolbarSplitDown_Click(object sender, RoutedEventArgs e) => ViewModel.SelectedWorkspace?.SelectedSurface?.SplitDown();
+    private void ShellSelector_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button) return;
+
+        var shells = ShellDetector.DetectShells();
+        var menu = new ContextMenu();
+
+        foreach (var shell in shells)
+        {
+            var item = new MenuItem { Header = shell.Name, Tag = shell.Path };
+            item.Click += (s, _) =>
+            {
+                if (s is MenuItem mi && mi.Tag is string path)
+                    ViewModel.SelectedWorkspace?.SelectedSurface?.OpenPaneWithShell(path);
+            };
+            menu.Items.Add(item);
+        }
+
+        menu.PlacementTarget = button;
+        menu.IsOpen = true;
+    }
     private void ToggleAgentChat_Click(object sender, RoutedEventArgs e) => ToggleAgentChat();
     private void ToolbarLayout2Col_Click(object sender, RoutedEventArgs e) => ApplyLayout(2, 1);
     private void ToolbarLayoutGrid_Click(object sender, RoutedEventArgs e) => ApplyLayout(2, 2);

--- a/src/Cmux/Views/SettingsWindow.xaml.cs
+++ b/src/Cmux/Views/SettingsWindow.xaml.cs
@@ -43,7 +43,7 @@ public partial class SettingsWindow : Window
         AgentChatFontFamilyCombo.ItemsSource = fontFamilies;
 
         // Detect available shells
-        var shells = DetectShells();
+        var shells = ShellDetector.DetectShells();
         ShellCombo.ItemsSource = shells;
         ShellCombo.DisplayMemberPath = "Name";
         ShellCombo.SelectedValuePath = "Path";
@@ -1013,62 +1013,6 @@ public partial class SettingsWindow : Window
         RefreshTerminalColorPreviews();
     }
 
-    private List<ShellInfo> DetectShells()
-    {
-        var shells = new List<ShellInfo>();
-
-        try
-        {
-            // PowerShell 7+
-            var pwshRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PowerShell");
-            if (Directory.Exists(pwshRoot))
-            {
-                var pwshPaths = Directory.GetFiles(pwshRoot, "pwsh.exe", SearchOption.AllDirectories);
-                foreach (var path in pwshPaths.OrderByDescending(p => p)) // newest first
-                    shells.Add(new ShellInfo("PowerShell 7", path));
-            }
-        } catch { /* ignore */ }
-
-        try
-        {
-            // Windows PowerShell
-            var system32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
-            var powershell = Path.Combine(system32, "WindowsPowerShell", "v1.0", "powershell.exe");
-            if (File.Exists(powershell))
-                shells.Add(new ShellInfo("Windows PowerShell", powershell));
-
-            // Command Prompt
-            var cmd = Path.Combine(system32, "cmd.exe");
-            if (File.Exists(cmd))
-                shells.Add(new ShellInfo("Command Prompt", cmd));
-
-            // WSL
-            var wslPath = Path.Combine(system32, "wsl.exe");
-            if (File.Exists(wslPath))
-                shells.Add(new ShellInfo("WSL", wslPath));
-        } catch { /* ignore */ }
-
-        try
-        {
-            // Git Bash
-            var gitBashPaths = new[]
-            {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", "bin", "bash.exe"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Git", "bin", "bash.exe"),
-            };
-            foreach (var path in gitBashPaths)
-            {
-                if (File.Exists(path))
-                {
-                    shells.Add(new ShellInfo("Git Bash", path));
-                    break;
-                }
-            }
-        } catch { /* ignore */ }
-
-        return shells;
-    }
-
     private static bool IsSystemLightTheme()
     {
         try
@@ -1091,5 +1035,4 @@ public partial class SettingsWindow : Window
         };
     }
 
-    private record ShellInfo(string Name, string Path);
 }


### PR DESCRIPTION
## Problem

Fixes #2

`DefaultShell` is correctly saved to `settings.json` but was never read when starting a session. All four `session.Start()` call sites in `SurfaceViewModel.cs` passed `null` as the command, always triggering automatic shell detection regardless of the user's setting.

## Solution

Added a `GetConfiguredShell()` helper that reads `SettingsService.Current.DefaultShell` and returns `null` if empty (preserving existing auto-detection behavior). Applied it to all four `session.Start()` call sites:

- `StartLocalSession()`
- `StartDaemonSession()` (two fallback paths)
- Daemon disconnection fallback

## Testing

- Set a non-default shell in Settings
- Opened a new tab → correct shell launched
- Left the setting empty → auto-detection still works as before