### PR TITLE
feat: Korean IME input, CJK wide character rendering, notifications, and DefaultShell fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ $RECYCLE.BIN/
 *.log
 [Ll]og/
 [Ll]ogs/
+
+# AI assistant config (developer-specific)
+CLAUDE.md

--- a/src/Cmux.Core/Models/TerminalNotification.cs
+++ b/src/Cmux.Core/Models/TerminalNotification.cs
@@ -6,6 +6,7 @@ public enum NotificationSource
     Osc99,
     Osc777,
     Cli,
+    AgentCompleted,
 }
 
 public record TerminalNotification

--- a/src/Cmux.Core/Terminal/TerminalBuffer.cs
+++ b/src/Cmux.Core/Terminal/TerminalBuffer.cs
@@ -130,33 +130,86 @@ public class TerminalBuffer
             _wrapPending = false;
         }
 
+        int charWidth = UnicodeWidth.GetWidth(c);
+
         if (InsertMode)
         {
-            // Shift characters right
-            for (int col = Cols - 1; col > CursorCol; col--)
-                _cells[CursorRow, col] = _cells[CursorRow, col - 1];
+            // Shift characters right by charWidth positions
+            for (int col = Cols - 1; col > CursorCol + charWidth - 1; col--)
+                _cells[CursorRow, col] = _cells[CursorRow, col - charWidth];
+        }
+
+        // For wide chars, check if there's room for 2 cells
+        if (charWidth == 2 && CursorCol + 1 >= Cols)
+        {
+            // Not enough room — wrap first
+            if (AutoWrapMode)
+            {
+                CarriageReturn();
+                LineFeed();
+            }
+            else
+            {
+                // Can't wrap — just write in last column as narrow
+                charWidth = 1;
+            }
         }
 
         if (CursorRow >= 0 && CursorRow < Rows && CursorCol >= 0 && CursorCol < Cols)
         {
+            // Clean up any wide character that we're overwriting.
+            // If we're writing over the LEFT half of a wide char, clear its continuation.
+            // If we're writing over the RIGHT half (continuation), clear the left half.
+            var existing = _cells[CursorRow, CursorCol];
+            if (existing.Width == 2 && CursorCol + 1 < Cols)
+            {
+                // Overwriting a wide char — clear its continuation cell
+                _cells[CursorRow, CursorCol + 1] = TerminalCell.Empty;
+            }
+            else if (existing.Width == 0 && CursorCol > 0)
+            {
+                // Overwriting a continuation cell — clear the wide char's left half
+                _cells[CursorRow, CursorCol - 1] = TerminalCell.Empty;
+            }
+
             _cells[CursorRow, CursorCol] = new TerminalCell
             {
                 Character = c,
                 Attribute = CurrentAttribute,
                 IsDirty = true,
-                Width = 1,
+                Width = charWidth,
             };
+
+            // Wide char: mark the next cell as a continuation (Width=0)
+            if (charWidth == 2 && CursorCol + 1 < Cols)
+            {
+                // Also clean up if the continuation slot was the left half of another wide char
+                if (CursorCol + 2 < Cols && _cells[CursorRow, CursorCol + 1].Width == 2)
+                    _cells[CursorRow, CursorCol + 2] = TerminalCell.Empty;
+
+                _cells[CursorRow, CursorCol + 1] = new TerminalCell
+                {
+                    Character = '\0',
+                    Attribute = CurrentAttribute,
+                    IsDirty = true,
+                    Width = 0, // continuation of wide char
+                };
+            }
         }
 
-        if (CursorCol + 1 >= Cols)
+        int advance = charWidth;
+        if (CursorCol + advance >= Cols)
         {
             _wrapPending = true;
+            // Position cursor at the last valid column
+            CursorCol = Cols - 1;
         }
         else
         {
-            CursorCol++;
+            CursorCol += advance;
         }
     }
+
 
     public void WriteString(string text)
     {
@@ -298,15 +351,21 @@ public class TerminalBuffer
 
         switch (mode)
         {
-            case 0:
+            case 0: // Erase from cursor to end of line
+                // If cursor is on a continuation cell, also clear the wide char's left half
+                if (CursorCol > 0 && _cells[CursorRow, CursorCol].Width == 0)
+                    _cells[CursorRow, CursorCol - 1] = TerminalCell.Empty;
                 for (int c = CursorCol; c < Cols; c++)
                     _cells[CursorRow, c] = TerminalCell.Empty;
                 break;
-            case 1:
+            case 1: // Erase from start of line to cursor
                 for (int c = 0; c <= CursorCol; c++)
                     _cells[CursorRow, c] = TerminalCell.Empty;
+                // If we stopped on the left half of a wide char, also clear continuation
+                if (CursorCol + 1 < Cols && _cells[CursorRow, CursorCol + 1].Width == 0)
+                    _cells[CursorRow, CursorCol + 1] = TerminalCell.Empty;
                 break;
-            case 2:
+            case 2: // Erase entire line
                 for (int c = 0; c < Cols; c++)
                     _cells[CursorRow, c] = TerminalCell.Empty;
                 break;
@@ -519,7 +578,13 @@ public class TerminalBuffer
     public void Backspace()
     {
         if (CursorCol > 0)
+        {
             CursorCol--;
+            // If we landed on a continuation cell (right half of wide char),
+            // step back one more to the actual character cell.
+            if (CursorCol > 0 && _cells[CursorRow, CursorCol].Width == 0)
+                CursorCol--;
+        }
         _wrapPending = false;
     }
 

--- a/src/Cmux.Core/Terminal/TerminalSession.cs
+++ b/src/Cmux.Core/Terminal/TerminalSession.cs
@@ -45,6 +45,7 @@ public sealed class TerminalSession : IDisposable
     public event Action? Redraw;
     public event Action? BellReceived;
     public event Action<byte[]>? RawOutputReceived;
+    public event Action? InputSent;
 
     public TerminalSession(string paneId, int cols = 120, int rows = 30)
     {
@@ -240,6 +241,7 @@ public sealed class TerminalSession : IDisposable
     public void Write(byte[] data)
     {
         if (_disposed) return;
+        InputSent?.Invoke();
 
         // Daemon mode: forward to daemon instead of local ConPTY
         if (DaemonWrite != null)

--- a/src/Cmux.Core/Terminal/UnicodeWidth.cs
+++ b/src/Cmux.Core/Terminal/UnicodeWidth.cs
@@ -1,0 +1,82 @@
+namespace Cmux.Core.Terminal;
+
+/// <summary>
+/// Provides Unicode character width calculation (wcwidth equivalent).
+/// Full-width CJK characters return 2; most others return 1.
+/// </summary>
+public static class UnicodeWidth
+{
+    /// <summary>
+    /// Returns the column width of a character: 2 for full-width / wide, 1 otherwise.
+    /// </summary>
+    public static int GetWidth(char c)
+    {
+        int cp = c;
+        return IsWide(cp) ? 2 : 1;
+    }
+
+    /// <summary>
+    /// Returns true if the codepoint occupies two terminal columns.
+    /// Covers CJK Unified Ideographs, Hangul, Katakana/Hiragana, fullwidth forms, etc.
+    /// Based on Unicode East Asian Width property (W and F categories).
+    /// </summary>
+    private static bool IsWide(int cp)
+    {
+        // Fullwidth Forms (FF01-FF60, FFE0-FFE6)
+        if (cp >= 0xFF01 && cp <= 0xFF60) return true;
+        if (cp >= 0xFFE0 && cp <= 0xFFE6) return true;
+
+        // CJK Radicals Supplement (2E80-2EFF)
+        if (cp >= 0x2E80 && cp <= 0x2EFF) return true;
+        // Kangxi Radicals (2F00-2FDF)
+        if (cp >= 0x2F00 && cp <= 0x2FDF) return true;
+        // Ideographic Description Characters (2FF0-2FFF)
+        if (cp >= 0x2FF0 && cp <= 0x2FFF) return true;
+
+        // CJK Symbols and Punctuation (3000-303F)
+        if (cp >= 0x3000 && cp <= 0x303F) return true;
+        // Hiragana (3040-309F)
+        if (cp >= 0x3040 && cp <= 0x309F) return true;
+        // Katakana (30A0-30FF)
+        if (cp >= 0x30A0 && cp <= 0x30FF) return true;
+        // Bopomofo (3100-312F)
+        if (cp >= 0x3100 && cp <= 0x312F) return true;
+        // Hangul Compatibility Jamo (3130-318F)
+        if (cp >= 0x3130 && cp <= 0x318F) return true;
+        // Kanbun (3190-319F)
+        if (cp >= 0x3190 && cp <= 0x319F) return true;
+        // Bopomofo Extended (31A0-31BF)
+        if (cp >= 0x31A0 && cp <= 0x31BF) return true;
+        // CJK Strokes (31C0-31EF)
+        if (cp >= 0x31C0 && cp <= 0x31EF) return true;
+        // Katakana Phonetic Extensions (31F0-31FF)
+        if (cp >= 0x31F0 && cp <= 0x31FF) return true;
+        // Enclosed CJK Letters and Months (3200-32FF)
+        if (cp >= 0x3200 && cp <= 0x32FF) return true;
+        // CJK Compatibility (3300-33FF)
+        if (cp >= 0x3300 && cp <= 0x33FF) return true;
+        // CJK Unified Ideographs Extension A (3400-4DBF)
+        if (cp >= 0x3400 && cp <= 0x4DBF) return true;
+        // CJK Unified Ideographs (4E00-9FFF)
+        if (cp >= 0x4E00 && cp <= 0x9FFF) return true;
+
+        // Yi Syllables and Radicals (A000-A4CF)
+        if (cp >= 0xA000 && cp <= 0xA4CF) return true;
+
+        // Hangul Jamo (1100-115F) — initial consonants
+        if (cp >= 0x1100 && cp <= 0x115F) return true;
+        // Hangul Jamo Extended-A (A960-A97C)
+        if (cp >= 0xA960 && cp <= 0xA97C) return true;
+
+        // Hangul Syllables (AC00-D7AF)
+        if (cp >= 0xAC00 && cp <= 0xD7AF) return true;
+
+        // CJK Compatibility Ideographs (F900-FAFF)
+        if (cp >= 0xF900 && cp <= 0xFAFF) return true;
+
+        // CJK Compatibility Forms (FE30-FE4F)
+        if (cp >= 0xFE30 && cp <= 0xFE4F) return true;
+
+        return false;
+    }
+}

--- a/src/Cmux/Controls/HangulComposer.cs
+++ b/src/Cmux/Controls/HangulComposer.cs
@@ -1,0 +1,349 @@
+namespace Cmux.Controls;
+
+/// <summary>
+/// Software Hangul syllable composer. Receives a stream of Hangul Compatibility
+/// Jamo (U+3131–U+3163) and composes them into Hangul Syllables (U+AC00–U+D7A3).
+///
+/// On a raw WPF FrameworkElement the OS IME fails to maintain composition state,
+/// delivering decomposed jamo instead of composed syllables. This class
+/// reimplements the composition algorithm so the terminal receives correct Korean text.
+/// </summary>
+public sealed class HangulComposer
+{
+    // ── Composition state ───────────────────────────────────────────────
+    private int _cho = -1;  // 초성 index (0-18), -1 = empty
+    private int _jung = -1; // 중성 index (0-20), -1 = empty
+    private int _jong = -1; // 종성 index (1-27), -1 = empty (0 = no 종성 in syllable formula)
+
+    // ── Hangul Compatibility Jamo → index tables ────────────────────────
+
+    // 초성 (initial consonants): 19 entries
+    // ㄱ ㄲ ㄴ ㄷ ㄸ ㄹ ㅁ ㅂ ㅃ ㅅ ㅆ ㅇ ㅈ ㅉ ㅊ ㅋ ㅌ ㅍ ㅎ
+    private static readonly char[] ChoJamo =
+    [
+        'ㄱ','ㄲ','ㄴ','ㄷ','ㄸ','ㄹ','ㅁ','ㅂ','ㅃ','ㅅ',
+        'ㅆ','ㅇ','ㅈ','ㅉ','ㅊ','ㅋ','ㅌ','ㅍ','ㅎ'
+    ];
+
+    // 중성 (medial vowels): 21 entries
+    // ㅏ ㅐ ㅑ ㅒ ㅓ ㅔ ㅕ ㅖ ㅗ ㅘ ㅙ ㅚ ㅛ ㅜ ㅝ ㅞ ㅟ ㅠ ㅡ ㅢ ㅣ
+    private static readonly char[] JungJamo =
+    [
+        'ㅏ','ㅐ','ㅑ','ㅒ','ㅓ','ㅔ','ㅕ','ㅖ','ㅗ','ㅘ',
+        'ㅙ','ㅚ','ㅛ','ㅜ','ㅝ','ㅞ','ㅟ','ㅠ','ㅡ','ㅢ','ㅣ'
+    ];
+
+    // 종성 (final consonants): indices 1-27 (0 = no final)
+    // (none) ㄱ ㄲ ㄳ ㄴ ㄵ ㄶ ㄷ ㄹ ㄺ ㄻ ㄼ ㄽ ㄾ ㄿ ㅀ ㅁ ㅂ ㅄ ㅅ ㅆ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎ
+    private static readonly char[] JongJamo =
+    [
+        '\0','ㄱ','ㄲ','ㄳ','ㄴ','ㄵ','ㄶ','ㄷ','ㄹ','ㄺ',
+        'ㄻ','ㄼ','ㄽ','ㄾ','ㄿ','ㅀ','ㅁ','ㅂ','ㅄ','ㅅ',
+        'ㅆ','ㅇ','ㅈ','ㅊ','ㅋ','ㅌ','ㅍ','ㅎ'
+    ];
+
+    // 종성 → 초성 mapping (a 종성 jamo can also serve as the next 초성)
+    // Maps 종성 index to 초성 index, or -1 if not possible (compound 종성)
+    private static readonly int[] JongToChoIndex =
+    [
+        -1, // 0: no final
+         0, // 1: ㄱ → ㄱ(0)
+         1, // 2: ㄲ → ㄲ(1)
+        -1, // 3: ㄳ (compound)
+         2, // 4: ㄴ → ㄴ(2)
+        -1, // 5: ㄵ (compound)
+        -1, // 6: ㄶ (compound)
+         3, // 7: ㄷ → ㄷ(3)
+         5, // 8: ㄹ → ㄹ(5)
+        -1, // 9: ㄺ (compound)
+        -1, //10: ㄻ (compound)
+        -1, //11: ㄼ (compound)
+        -1, //12: ㄽ (compound)
+        -1, //13: ㄾ (compound)
+        -1, //14: ㄿ (compound)
+        -1, //15: ㅀ (compound)
+         6, //16: ㅁ → ㅁ(6)
+         7, //17: ㅂ → ㅂ(7)
+        -1, //18: ㅄ (compound)
+         9, //19: ㅅ → ㅅ(9)
+        10, //20: ㅆ → ㅆ(10)
+        11, //21: ㅇ → ㅇ(11)
+        12, //22: ㅈ → ㅈ(12)
+        14, //23: ㅊ → ㅊ(14)
+        15, //24: ㅋ → ㅋ(15)
+        16, //25: ㅌ → ㅌ(16)
+        17, //26: ㅍ → ㅍ(17)
+        18, //27: ㅎ → ㅎ(18)
+    ];
+
+    // Compound 종성 split: compound index → (left 종성, right 초성)
+    // Used when a vowel follows a compound 종성, splitting it.
+    private static readonly Dictionary<int, (int leftJong, int rightCho)> CompoundJongSplit = new()
+    {
+        [3]  = (1, 9),   // ㄳ → ㄱ(jong:1) + ㅅ(cho:9)
+        [5]  = (4, 12),  // ㄵ → ㄴ(jong:4) + ㅈ(cho:12)
+        [6]  = (4, 18),  // ㄶ → ㄴ(jong:4) + ㅎ(cho:18)
+        [9]  = (8, 0),   // ㄺ → ㄹ(jong:8) + ㄱ(cho:0)
+        [10] = (8, 6),   // ㄻ → ㄹ(jong:8) + ㅁ(cho:6)
+        [11] = (8, 7),   // ㄼ → ㄹ(jong:8) + ㅂ(cho:7)
+        [12] = (8, 9),   // ㄽ → ㄹ(jong:8) + ㅅ(cho:9)
+        [13] = (8, 16),  // ㄾ → ㄹ(jong:8) + ㅌ(cho:16)
+        [14] = (8, 17),  // ㄿ → ㄹ(jong:8) + ㅍ(cho:17)
+        [15] = (8, 18),  // ㅀ → ㄹ(jong:8) + ㅎ(cho:18)
+        [18] = (17, 9),  // ㅄ → ㅂ(jong:17) + ㅅ(cho:9)
+    };
+
+    // Compound 종성 composition: (left 종성, right 종성) → compound index
+    private static readonly Dictionary<(int, int), int> CompoundJongMap = new()
+    {
+        [(1, 19)]  = 3,  // ㄱ+ㅅ = ㄳ
+        [(4, 22)]  = 5,  // ㄴ+ㅈ = ㄵ
+        [(4, 27)]  = 6,  // ㄴ+ㅎ = ㄶ
+        [(8, 1)]   = 9,  // ㄹ+ㄱ = ㄺ
+        [(8, 16)]  = 10, // ㄹ+ㅁ = ㄻ
+        [(8, 17)]  = 11, // ㄹ+ㅂ = ㄼ
+        [(8, 19)]  = 12, // ㄹ+ㅅ = ㄽ
+        [(8, 25)]  = 13, // ㄹ+ㅌ = ㄾ
+        [(8, 26)]  = 14, // ㄹ+ㅍ = ㄿ
+        [(8, 27)]  = 15, // ㄹ+ㅎ = ㅀ
+        [(17, 19)] = 18, // ㅂ+ㅅ = ㅄ
+    };
+
+    // Compound 중성 composition: (left, right) → compound vowel index
+    private static readonly Dictionary<(int, int), int> CompoundJungMap = new()
+    {
+        [(8, 0)]   = 9,  // ㅗ+ㅏ = ㅘ
+        [(8, 1)]   = 10, // ㅗ+ㅐ = ㅙ
+        [(8, 20)]  = 11, // ㅗ+ㅣ = ㅚ
+        [(13, 4)]  = 14, // ㅜ+ㅓ = ㅝ
+        [(13, 5)]  = 15, // ㅜ+ㅔ = ㅞ
+        [(13, 20)] = 16, // ㅜ+ㅣ = ㅟ
+        [(18, 20)] = 19, // ㅡ+ㅣ = ㅢ
+    };
+
+    // ── Public API ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Feed a character into the composer. Returns the string to send to ConPTY.
+    /// May return empty string (character buffered), one syllable, or multiple
+    /// characters (flushed buffer + new state).
+    /// </summary>
+    public string Feed(char c)
+    {
+        // Already-composed Hangul syllable — decompose and buffer it so the
+        // next input character can modify it (e.g. add 종성). The OS IME on a
+        // raw FrameworkElement sends some syllables pre-composed (e.g. "느")
+        // but a following consonant should become its 종성 (e.g. "느"+ㄴ → "는").
+        if (c is >= '\uAC00' and <= '\uD7A3')
+        {
+            var flushed = Flush();
+            int offset = c - 0xAC00;
+            _cho = offset / (21 * 28);
+            _jung = (offset / 28) % 21;
+            int jong = offset % 28;
+            _jong = jong > 0 ? jong : -1;
+            return flushed;
+        }
+
+        int choIdx = GetChoIndex(c);
+        int jungIdx = GetJungIndex(c);
+
+        // Not a Hangul jamo? Flush and pass through.
+        if (choIdx < 0 && jungIdx < 0)
+        {
+            var flushed = Flush();
+            return flushed + c;
+        }
+
+        // ── Consonant input ─────────────────────────────────────────
+        if (choIdx >= 0 && jungIdx < 0)
+        {
+            int jongIdx = GetJongIndexFromCho(choIdx);
+
+            // State: empty → start new 초성
+            if (_cho < 0)
+            {
+                _cho = choIdx;
+                return "";
+            }
+
+            // State: 초성 only → flush previous 초성, start new
+            if (_jung < 0)
+            {
+                string prev = ChoJamo[_cho].ToString();
+                _cho = choIdx;
+                _jung = -1;
+                _jong = -1;
+                return prev;
+            }
+
+            // State: 초성+중성 (no 종성) → try adding as 종성
+            if (_jong < 0)
+            {
+                if (jongIdx >= 0)
+                {
+                    _jong = jongIdx;
+                    return "";
+                }
+                // Can't be 종성 → flush syllable, start new 초성
+                string syllable = ComposeSyllable();
+                _cho = choIdx;
+                _jung = -1;
+                _jong = -1;
+                return syllable;
+            }
+
+            // State: 초성+중성+종성 → try compound 종성
+            if (jongIdx >= 0 && CompoundJongMap.TryGetValue((_jong, jongIdx), out int compound))
+            {
+                _jong = compound;
+                return "";
+            }
+
+            // Can't compound → flush syllable, start new 초성
+            {
+                string syllable = ComposeSyllable();
+                _cho = choIdx;
+                _jung = -1;
+                _jong = -1;
+                return syllable;
+            }
+        }
+
+        // ── Vowel input ─────────────────────────────────────────────
+        if (jungIdx >= 0)
+        {
+            // State: empty → output bare vowel
+            if (_cho < 0)
+            {
+                var flushed = Flush();
+                return flushed + JungJamo[jungIdx];
+            }
+
+            // State: 초성 only → add 중성
+            if (_jung < 0)
+            {
+                _jung = jungIdx;
+                return "";
+            }
+
+            // State: 초성+중성 (no 종성) → try compound vowel
+            if (_jong < 0)
+            {
+                if (CompoundJungMap.TryGetValue((_jung, jungIdx), out int compound))
+                {
+                    _jung = compound;
+                    return "";
+                }
+                // Can't compound → flush syllable, start new state with vowel
+                string syllable = ComposeSyllable();
+                _cho = -1;
+                _jung = -1;
+                _jong = -1;
+                return syllable + JungJamo[jungIdx];
+            }
+
+            // State: 초성+중성+종성 → split 종성: left stays, right becomes new 초성 + this vowel
+            if (CompoundJongSplit.TryGetValue(_jong, out var split))
+            {
+                // Compound 종성: split it
+                _jong = split.leftJong;
+                string syllable = ComposeSyllable();
+                _cho = split.rightCho;
+                _jung = jungIdx;
+                _jong = -1;
+                return syllable;
+            }
+            else
+            {
+                // Simple 종성: move it to next 초성
+                int nextCho = JongToChoIndex[_jong];
+                if (nextCho >= 0)
+                {
+                    _jong = -1; // Remove 종성 from current syllable
+                    string syllable = ComposeSyllable();
+                    _cho = nextCho;
+                    _jung = jungIdx;
+                    _jong = -1;
+                    return syllable;
+                }
+                else
+                {
+                    // Shouldn't happen, but flush everything
+                    string syllable = ComposeSyllable();
+                    _cho = -1;
+                    _jung = -1;
+                    _jong = -1;
+                    return syllable + JungJamo[jungIdx];
+                }
+            }
+        }
+
+        // Fallback (shouldn't reach here)
+        return Flush() + c;
+    }
+
+    /// <summary>
+    /// Flush any buffered composition state. Call this when a non-composable
+    /// event occurs (Enter, space, focus lost, etc.).
+    /// </summary>
+    public string Flush()
+    {
+        if (_cho < 0) return "";
+
+        string result;
+        if (_jung < 0)
+        {
+            // Only 초성 → output as bare consonant jamo
+            result = ChoJamo[_cho].ToString();
+        }
+        else
+        {
+            result = ComposeSyllable();
+        }
+
+        _cho = -1;
+        _jung = -1;
+        _jong = -1;
+        return result;
+    }
+
+    /// <summary>Whether there is an active composition.</summary>
+    public bool IsComposing => _cho >= 0;
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    private string ComposeSyllable()
+    {
+        if (_cho < 0 || _jung < 0) return "";
+        int jongValue = _jong >= 0 ? _jong : 0;
+        int code = 0xAC00 + (_cho * 21 + _jung) * 28 + jongValue;
+        return ((char)code).ToString();
+    }
+
+    private static int GetChoIndex(char c)
+    {
+        for (int i = 0; i < ChoJamo.Length; i++)
+            if (ChoJamo[i] == c) return i;
+        return -1;
+    }
+
+    private static int GetJungIndex(char c)
+    {
+        for (int i = 0; i < JungJamo.Length; i++)
+            if (JungJamo[i] == c) return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// Given a 초성 index, return the corresponding 종성 index (or -1).
+    /// Not all 초성 can be used as 종성 (e.g. ㄸ, ㅃ, ㅉ cannot).
+    /// </summary>
+    private static int GetJongIndexFromCho(int choIdx)
+    {
+        char c = ChoJamo[choIdx];
+        for (int i = 1; i < JongJamo.Length; i++)
+            if (JongJamo[i] == c) return i;
+        return -1;
+    }
+}

--- a/src/Cmux/Controls/NotificationPanel.xaml
+++ b/src/Cmux/Controls/NotificationPanel.xaml
@@ -53,7 +53,9 @@
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <Border Padding="16,10" BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="0,0,0,1">
+                                BorderThickness="0,0,0,1" Cursor="Hand"
+                                MouseLeftButtonUp="NotificationItem_Click"
+                                Background="Transparent">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />

--- a/src/Cmux/Controls/NotificationPanel.xaml.cs
+++ b/src/Cmux/Controls/NotificationPanel.xaml.cs
@@ -1,11 +1,25 @@
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using Cmux.Core.Models;
 
 namespace Cmux.Controls;
 
 public partial class NotificationPanel : UserControl
 {
+    /// <summary>Raised when a notification item is clicked.</summary>
+    public event Action<TerminalNotification>? NotificationClicked;
+
     public NotificationPanel()
     {
         InitializeComponent();
+    }
+
+    private void NotificationItem_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: TerminalNotification notification })
+        {
+            NotificationClicked?.Invoke(notification);
+        }
     }
 }

--- a/src/Cmux/Controls/TerminalControl.cs
+++ b/src/Cmux/Controls/TerminalControl.cs
@@ -70,6 +70,9 @@ public class TerminalControl : FrameworkElement
     private readonly StringBuilder _textRunBuffer = new();
     private bool _suppressNextEnterTextInput;
 
+    // Software Hangul composer for CJK IME input on raw FrameworkElement
+    private readonly HangulComposer _hangulComposer = new();
+
     /// <summary>Fired when the pane wants focus.</summary>
     public event Action? FocusRequested;
     public event Action<string>? CommandSubmitted;
@@ -441,7 +444,12 @@ public class TerminalControl : FrameworkElement
                         cell = TerminalCell.Empty;
                     }
 
+                    // Skip continuation cells of wide characters (Width=0)
+                    if (cell.Width == 0)
+                        continue;
+
                     double x = c * _cellWidth;
+                    double cellRenderWidth = cell.Width >= 2 ? _cellWidth * 2 : _cellWidth;
                     var attr = cell.Attribute;
                     bool isSelected = _selection.IsSelected(visRow, c);
                     bool isInverse = attr.Flags.HasFlag(CellFlags.Inverse) != isSelected;
@@ -466,27 +474,30 @@ public class TerminalControl : FrameworkElement
                     if (!cellBg.IsDefault)
                     {
                         dc.DrawRectangle(GetCachedBrush(ToWpfColor(cellBg)), null,
-                            new Rect(x, y, _cellWidth, _cellHeight));
+                            new Rect(x, y, cellRenderWidth, _cellHeight));
                     }
 
                     // Search match highlight (behind text)
                     bool isSearchMatch = searchMatchSet.Contains((visRow, c));
                     bool isCurrentMatch = currentMatchSet.Contains((visRow, c));
                     if (isCurrentMatch)
-                        dc.DrawRectangle(currentMatchBrush, null, new Rect(x, y, _cellWidth, _cellHeight));
+                        dc.DrawRectangle(currentMatchBrush, null, new Rect(x, y, cellRenderWidth, _cellHeight));
                     else if (isSearchMatch)
-                        dc.DrawRectangle(searchMatchBrush, null, new Rect(x, y, _cellWidth, _cellHeight));
+                        dc.DrawRectangle(searchMatchBrush, null, new Rect(x, y, cellRenderWidth, _cellHeight));
 
                     // URL hover highlight
                     if (_hoveredUrl is { } url && visRow == url.row && c >= url.startCol && c <= url.endCol)
                     {
                         var urlPen = new Pen(GetCachedBrush(Color.FromRgb(0x81, 0x8C, 0xF8)), 1);
                         urlPen.Freeze();
-                        dc.DrawLine(urlPen, new Point(x, y + _cellHeight - 1), new Point(x + _cellWidth, y + _cellHeight - 1));
+                        dc.DrawLine(urlPen, new Point(x, y + _cellHeight - 1), new Point(x + cellRenderWidth, y + _cellHeight - 1));
                     }
 
-                    // Text batching: group consecutive characters with same visual style
+                    // Text batching: group consecutive NARROW characters with same visual style.
+                    // Wide characters (Width >= 2) are rendered individually at exact grid
+                    // positions to avoid font-metric misalignment.
                     bool hasChar = cell.Character != '\0' && cell.Character != ' ';
+                    bool isWide = cell.Width >= 2;
                     if (hasChar)
                     {
                         var fgColor = cellFg.IsDefault ? ToWpfColor(_theme.Foreground) : ToWpfColor(cellFg);
@@ -496,29 +507,73 @@ public class TerminalControl : FrameworkElement
                         bool underline = attr.Flags.HasFlag(CellFlags.Underline);
                         bool strikethrough = attr.Flags.HasFlag(CellFlags.Strikethrough);
 
-                        // Style changed? Flush the current run first
-                        if (runStartCol >= 0 && (fgColor != runFgColor || bold != runBold ||
-                            italic != runItalic || dim != runDim ||
-                            underline != runUnderline || strikethrough != runStrikethrough))
+                        if (isWide)
                         {
-                            FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
-                            runStartCol = -1;
-                        }
+                            // Flush any pending narrow run before rendering wide char
+                            if (runStartCol >= 0)
+                            {
+                                FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
+                                runStartCol = -1;
+                            }
 
-                        // Start new run or continue existing
-                        if (runStartCol < 0)
+                            // Render wide character individually at exact grid position
+                            var brush = dim
+                                ? GetCachedBrush(Color.FromArgb(128, fgColor.R, fgColor.G, fgColor.B))
+                                : GetCachedBrush(fgColor);
+                            var tf = GetTypeface(bold, italic);
+                            var charText = new FormattedText(
+                                cell.Character.ToString(),
+                                CultureInfo.CurrentCulture,
+                                FlowDirection.LeftToRight,
+                                tf,
+                                _fontSize,
+                                brush,
+                                dpi);
+                            // Center the glyph within the 2-cell space
+                            double glyphOffset = (cellRenderWidth - charText.WidthIncludingTrailingWhitespace) / 2;
+                            dc.DrawText(charText, new Point(x + Math.Max(0, glyphOffset), y));
+
+                            if (underline)
+                            {
+                                var pen = new Pen(brush, 1);
+                                pen.Freeze();
+                                dc.DrawLine(pen, new Point(x, y + _cellHeight - 1), new Point(x + cellRenderWidth, y + _cellHeight - 1));
+                            }
+                            if (strikethrough)
+                            {
+                                var pen = new Pen(brush, 1);
+                                pen.Freeze();
+                                dc.DrawLine(pen, new Point(x, y + _cellHeight / 2), new Point(x + cellRenderWidth, y + _cellHeight / 2));
+                            }
+                        }
+                        else
                         {
-                            runStartCol = c;
-                            runFgColor = fgColor;
-                            runBold = bold;
-                            runItalic = italic;
-                            runDim = dim;
-                            runUnderline = underline;
-                            runStrikethrough = strikethrough;
-                            _textRunBuffer.Clear();
-                        }
+                            // Narrow character — batch into text run
 
-                        _textRunBuffer.Append(cell.Character);
+                            // Style changed? Flush the current run first
+                            if (runStartCol >= 0 && (fgColor != runFgColor || bold != runBold ||
+                                italic != runItalic || dim != runDim ||
+                                underline != runUnderline || strikethrough != runStrikethrough))
+                            {
+                                FlushTextRun(dc, dpi, y, runStartCol, runFgColor, runBold, runItalic, runDim, runUnderline, runStrikethrough);
+                                runStartCol = -1;
+                            }
+
+                            // Start new run or continue existing
+                            if (runStartCol < 0)
+                            {
+                                runStartCol = c;
+                                runFgColor = fgColor;
+                                runBold = bold;
+                                runItalic = italic;
+                                runDim = dim;
+                                runUnderline = underline;
+                                runStrikethrough = strikethrough;
+                                _textRunBuffer.Clear();
+                            }
+
+                            _textRunBuffer.Append(cell.Character);
+                        }
                     }
                     else if (runStartCol >= 0)
                     {
@@ -831,6 +886,18 @@ public class TerminalControl : FrameworkElement
             return;
         }
 
+        // Flush any pending Hangul composition before processing special keys
+        if (_hangulComposer.IsComposing)
+        {
+            var flushed = _hangulComposer.Flush();
+            if (!string.IsNullOrEmpty(flushed))
+            {
+                EnsureLiveView();
+                TrackInputText(flushed);
+                _session.Write(flushed);
+            }
+        }
+
         bool appCursor = _session.Buffer.ApplicationCursorKeys;
         string? sequence = KeyToVtSequence(e.Key, modifiers, appCursor);
         if (sequence != null)
@@ -894,9 +961,19 @@ public class TerminalControl : FrameworkElement
             return;
         }
 
-        EnsureLiveView();
-        TrackInputText(e.Text);
-        _session.Write(e.Text);
+        // Feed each character through the Hangul composer.
+        // On a raw FrameworkElement, the OS IME delivers decomposed jamo
+        // instead of composed syllables. The composer reassembles them.
+        foreach (char c in e.Text)
+        {
+            var composed = _hangulComposer.Feed(c);
+            if (!string.IsNullOrEmpty(composed))
+            {
+                EnsureLiveView();
+                TrackInputText(composed);
+                _session.Write(composed);
+            }
+        }
         _selection.ClearSelection();
     }
 

--- a/src/Cmux/ViewModels/MainViewModel.cs
+++ b/src/Cmux/ViewModels/MainViewModel.cs
@@ -239,24 +239,31 @@ public partial class MainViewModel : ObservableObject
     public void JumpToLatestUnread()
     {
         var latest = _notificationService.GetLatestUnread();
-        if (latest == null) return;
+        if (latest != null)
+            NavigateToNotification(latest);
+    }
 
-        // Find the workspace and surface
-        var workspace = Workspaces.FirstOrDefault(w => w.Workspace.Id == latest.WorkspaceId);
+    public void NavigateToNotification(TerminalNotification notification)
+    {
+        var workspace = Workspaces.FirstOrDefault(w => w.Workspace.Id == notification.WorkspaceId);
         if (workspace != null)
         {
             SelectedWorkspace = workspace;
-            var surface = workspace.Surfaces.FirstOrDefault(s => s.Surface.Id == latest.SurfaceId);
+            var surface = workspace.Surfaces.FirstOrDefault(s => s.Surface.Id == notification.SurfaceId);
             if (surface != null)
             {
                 workspace.SelectedSurface = surface;
-                if (latest.PaneId != null)
+                if (notification.PaneId != null)
                 {
-                    surface.FocusPane(latest.PaneId);
+                    surface.FocusPane(notification.PaneId);
                 }
             }
-            _notificationService.MarkAsRead(latest.Id);
+            _notificationService.MarkAsRead(notification.Id);
         }
+
+        // Close the notification panel after navigating
+        if (NotificationPanelVisible)
+            ToggleNotificationPanel();
     }
 
     [RelayCommand]

--- a/src/Cmux/ViewModels/SurfaceViewModel.cs
+++ b/src/Cmux/ViewModels/SurfaceViewModel.cs
@@ -37,6 +37,21 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
 
     public event Action<string>? WorkingDirectoryChanged;
 
+    /// <summary>Timestamp of the last terminal output received (UTC ticks).</summary>
+    public long LastOutputTicks { get; set; }
+
+    /// <summary>Timestamp when the current output burst started (UTC ticks). Reset after idle.</summary>
+    public long OutputBurstStartTicks { get; set; }
+
+    /// <summary>Timestamp when this surface was created (UTC ticks). Used to suppress startup notifications.</summary>
+    public long CreatedTicks { get; } = DateTime.UtcNow.Ticks;
+
+    /// <summary>Whether user input has been sent since the last idle notification.</summary>
+    public bool HasUserInput { get; set; }
+
+    /// <summary>Whether an idle notification has been sent for the current burst.</summary>
+    public bool IdleNotified { get; set; }
+
     /// <summary>Gets the shell process PID from the focused pane session.</summary>
     public int? ShellPid
     {
@@ -96,6 +111,10 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
     private void OnDaemonRawOutput(string paneId, byte[] data)
     {
         if (!_daemonPanes.Contains(paneId)) return;
+        var now = DateTime.UtcNow.Ticks;
+        if (OutputBurstStartTicks == 0)
+            OutputBurstStartTicks = now;
+        LastOutputTicks = now;
         if (_sessions.TryGetValue(paneId, out var session))
             session.FeedOutput(data);
     }
@@ -124,6 +143,8 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
     private void OnDaemonBellReceived(string paneId)
     {
         if (!_daemonPanes.Contains(paneId)) return;
+        // BEL triggers visual bell only (handled by TerminalControl rendering).
+        // It does NOT create a notification — that's by design.
     }
 
     private void OnDaemonDisconnected()
@@ -401,7 +422,7 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
             {
                 DaemonLog($"[DaemonSession:{paneId}] Calling CreateSessionAsync ({initCols}x{initRows})...");
                 var result = await daemon.CreateSessionAsync(
-                    paneId, initCols, initRows, effectiveCwd);
+                    paneId, initCols, initRows, effectiveCwd, shell);
 
                 if (result == null)
                 {
@@ -494,6 +515,16 @@ public partial class SurfaceViewModel : ObservableObject, IDisposable
         {
             if (paneId == FocusedPaneId)
                 WorkingDirectoryChanged?.Invoke(dir);
+        };
+
+        session.InputSent += () => HasUserInput = true;
+
+        session.OutputReceived += () =>
+        {
+            var now = DateTime.UtcNow.Ticks;
+            if (OutputBurstStartTicks == 0)
+                OutputBurstStartTicks = now;
+            LastOutputTicks = now;
         };
 
         session.NotificationReceived += (title, subtitle, body) =>

--- a/src/Cmux/ViewModels/WorkspaceViewModel.cs
+++ b/src/Cmux/ViewModels/WorkspaceViewModel.cs
@@ -53,6 +53,7 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
     private readonly NotificationService _notificationService;
     private System.Threading.Timer? _infoRefreshTimer;
 
+
     public WorkspaceViewModel(Workspace workspace, NotificationService notificationService)
     {
         Workspace = workspace;
@@ -155,7 +156,7 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
                 }
             }
 
-            // AI agent detection
+            // AI agent detection (works for local sessions with ShellPid)
             var activeSurface = SelectedSurface;
             if (activeSurface?.ShellPid is int pid and > 0)
             {
@@ -165,6 +166,52 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
                     DetectedAgent = agent;
                     OnPropertyChanged(nameof(AgentLabel));
                     OnPropertyChanged(nameof(AgentIcon));
+                }
+            }
+
+            // Output idle detection: works for both daemon and local sessions.
+            // When terminal output has been active for 2+ seconds and then goes
+            // quiet for 5+ seconds, create a notification.
+            if (activeSurface != null)
+            {
+                var lastOutput = activeSurface.LastOutputTicks;
+                var burstStart = activeSurface.OutputBurstStartTicks;
+                if (lastOutput > 0 && burstStart > 0)
+                {
+                    var now = DateTime.UtcNow.Ticks;
+                    var quietSeconds = (now - lastOutput) / TimeSpan.TicksPerSecond;
+                    var burstDuration = (lastOutput - burstStart) / TimeSpan.TicksPerSecond;
+
+                    // Only notify if user has actually sent input to the terminal.
+                    // This prevents false notifications from shell startup, daemon
+                    // reconnect output, terminal redraws, etc.
+                    if (quietSeconds >= 5 && burstDuration >= 2 && !activeSurface.IdleNotified && activeSurface.HasUserInput)
+                    {
+                        activeSurface.IdleNotified = true;
+                        var label = DetectedAgent != AgentType.None
+                            ? AgentDetector.GetLabel(DetectedAgent)
+                            : "Terminal";
+                        // Must dispatch to UI thread — RefreshInfo runs on ThreadPool
+                        System.Windows.Application.Current?.Dispatcher.BeginInvoke(() =>
+                        {
+                            _notificationService.AddNotification(
+                                Workspace.Id,
+                                activeSurface.Surface.Id,
+                                paneId: null,
+                                title: $"{label} ready",
+                                subtitle: null,
+                                body: "Task output has completed.",
+                                source: NotificationSource.AgentCompleted);
+                        });
+                        // Reset tracking so next input→output cycle can trigger again
+                        activeSurface.OutputBurstStartTicks = 0;
+                        activeSurface.HasUserInput = false;
+                    }
+                    else if (quietSeconds < 2)
+                    {
+                        // Still active — reset idle flag
+                        activeSurface.IdleNotified = false;
+                    }
                 }
             }
         }
@@ -193,6 +240,19 @@ public partial class WorkspaceViewModel : ObservableObject, IDisposable
     partial void OnAccentColorChanged(string value)
     {
         Workspace.AccentColor = value;
+    }
+
+    partial void OnSelectedSurfaceChanged(SurfaceViewModel? value)
+    {
+        // Reset idle tracking when switching surfaces/tabs to avoid
+        // false notifications from terminal reconnect/redraw output.
+        if (value != null)
+        {
+            value.OutputBurstStartTicks = 0;
+            value.LastOutputTicks = 0;
+        }
+        if (value != null)
+            value.IdleNotified = false;
     }
 
     private static bool IsPrivateUseGlyph(string? value)

--- a/src/Cmux/Views/MainWindow.xaml
+++ b/src/Cmux/Views/MainWindow.xaml
@@ -455,7 +455,8 @@
                     </ContentControl>
 
                     <!-- Notification panel overlay -->
-                    <controls:NotificationPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="0"
+                    <controls:NotificationPanel x:Name="NotificationPanelControl"
+                        Grid.Row="0" Grid.RowSpan="3" Grid.Column="0"
                         HorizontalAlignment="Right"
                         Visibility="{Binding NotificationPanelVisible, Converter={StaticResource BoolToVisibility}}"
                         DataContext="{Binding}" />

--- a/src/Cmux/Views/MainWindow.xaml.cs
+++ b/src/Cmux/Views/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ public partial class MainWindow : Window
 
         CommandPaletteControl.PaletteClosed += () => FocusTerminal();
         CommandPaletteControl.ItemExecuted += item => FocusTerminal();
+        NotificationPanelControl.NotificationClicked += n => ViewModel.NavigateToNotification(n);
 
 
         // Wire snippet picker events


### PR DESCRIPTION
## Summary

Complements #5 with user-facing features and additional CJK rendering fixes:

### Korean IME Input (HangulComposer)
- Software Hangul syllable composition for WPF FrameworkElement where the OS IME fails to maintain composition state
- Full support: compound vowels, compound finals, syllable splitting, pre-composed syllable decomposition
- Flush on special keys (Enter, arrows, etc.)

### CJK Wide Character Rendering
- `UnicodeWidth` utility class (same structure as #5, extended with Hangul Jamo U+1100-U+115F and Hangul Jamo Extended-A U+A960-U+A97C)
- Wide character overwrite cleanup (orphaned continuation cells)
- Backspace skips continuation cells (Width=0)
- InsertMode shifts by charWidth instead of always 1
- Renderer draws wide characters individually for pixel-perfect grid alignment

### DefaultShell Daemon Fix
- Pass configured shell to `DaemonClient.CreateSessionAsync` — fixes settings being ignored for daemon-backed sessions

### Notification System
- Output idle detection: notifies when terminal output goes quiet after sustained activity following user input
- Agent completion alerts (AgentDetector transition + idle detection)
- Click notification to navigate to source workspace/surface
- Guards against false positives: user input required, startup grace period, per-surface idle tracking, UI thread dispatch

## Relation to #5

This PR is designed to complement #5:
- `UnicodeWidth.cs` follows the same class structure with additional ranges
- Wide char `TerminalBuffer` changes extend #5 approach with overwrite cleanup, backspace handling, and InsertMode fixes
- No overlap with #5 security, thread safety, or VtParser changes

## Test plan
- [x] Korean IME input composition (syllable assembly, jongseong handling)
- [x] English input unaffected
- [x] Wide character rendering: no gaps between CJK characters
- [x] Backspace over wide characters: no display misalignment
- [x] DefaultShell: setting applied on daemon session start
- [x] Notifications: 1 per input cycle, no false positives on idle workspaces
- [x] Click notification: navigates to correct workspace
- [ ] Japanese/Chinese input testing