### PR TITLE
Fix: CLI named-pipe deadlock on Windows (UTF-8 BOM + AutoFlush FlushFileBuffers)

### DIFF
--- a/src/Cmux.Core/IPC/NamedPipeServer.cs
+++ b/src/Cmux.Core/IPC/NamedPipeServer.cs
@@ -11,6 +11,15 @@ namespace Cmux.Core.IPC;
 /// </summary>
 public sealed class NamedPipeServer : IDisposable
 {
+    // UTF-8 WITHOUT a BOM. Using Encoding.UTF8 (which emits a BOM) together with
+    // StreamWriter { AutoFlush = true } makes the AutoFlush setter flush the 3-byte
+    // BOM preamble at construction time. On a Windows named pipe StreamWriter.Flush ->
+    // PipeStream.Flush -> FlushFileBuffers blocks until the peer drains the pipe.
+    // Because both ends construct their writer before their first read, each blocks
+    // waiting for the other to read -> mutual deadlock (no command ever executes).
+    // A BOM-less encoding makes that initial flush a no-op and avoids the deadlock.
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     private readonly string _pipeName;
     private CancellationTokenSource? _cts;
     private Task? _listenTask;
@@ -70,8 +79,8 @@ public sealed class NamedPipeServer : IDisposable
         {
             using (pipe)
             {
-                using var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
-                using var writer = new StreamWriter(pipe, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+                using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
+                using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
 
                 var requestLine = await reader.ReadLineAsync(ct);
                 if (string.IsNullOrEmpty(requestLine)) return;
@@ -208,6 +217,10 @@ public sealed class NamedPipeServer : IDisposable
 /// </summary>
 public static class NamedPipeClient
 {
+    // See NamedPipeServer.Utf8NoBom: a BOM would be flushed at writer construction
+    // (AutoFlush) and deadlock against FlushFileBuffers on the Windows named pipe.
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     public static async Task<string> SendCommand(string command, Dictionary<string, string>? args = null, string? tag = null, int timeoutMs = 5000)
     {
         var pipeName = string.IsNullOrEmpty(tag) ? "cmux" : $"cmux-{tag}";
@@ -217,8 +230,8 @@ public static class NamedPipeClient
 
         await pipe.ConnectAsync(cts.Token);
 
-        using var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
-        using var writer = new StreamWriter(pipe, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+        using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
+        using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
 
         var sb = new StringBuilder(command);
         if (args != null)


### PR DESCRIPTION
## Problem

On Windows the `cmux` CLI hangs forever and never does anything — `cmux notify`, `cmux split`, `cmux surface create`, `cmux workspace …`, `cmux status` all block indefinitely and the in-app command handler (`MainViewModel.HandlePipeCommand`) is **never reached**. The pipe connects fine, but no command is ever processed and no response is sent.

(The same `OnCommand` handler works when invoked in-process by the side-panel agent via `AgentRuntimeService.ExecutePipeCommandAsync`, which bypasses the pipe — so the handler itself is fine. The fault is purely in the named-pipe transport.)

## Root cause

Both ends build their `StreamWriter` like this:

```csharp
using var writer = new StreamWriter(pipe, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
```

The object initializer `{ AutoFlush = true }` runs the **`AutoFlush` setter, which performs an immediate `Flush()` at construction time**. `Encoding.UTF8` emits a 3-byte BOM preamble, so that flush writes the BOM and calls `PipeStream.Flush()` → **`FlushFileBuffers`**, which **on a Windows named pipe blocks until the peer reads the bytes**.

Because each side constructs its writer *before* its first read (`ReadLineAsync`), both sides block inside the `StreamWriter` constructor, each waiting for the other to read its BOM. Neither ever reaches its read → **mutual deadlock**. No bytes are ever exchanged.

This is Windows-specific: the macOS original this was ported from uses Unix-domain sockets, whose `Stream.Flush` is a no-op, so the BOM flush never blocks there.

### How it was confirmed

Reproduced in isolation by compiling the unmodified `NamedPipeServer`/`NamedPipeClient` and running a server + client against a test pipe. Instrumented logging shows both sides stop exactly at writer construction:

```
[cli] reader erstellt
[srv] reader erstellt
… (both stop before "writer erstellt") → deadlock
```

With the fix the same harness round-trips `STATUS` in ~20 ms and the full sequence (`ReadLineAsync` → `OnCommand` → response) completes.

## Fix

Use a BOM-less UTF-8 encoding (`new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)`) for the pipe `StreamReader`/`StreamWriter` on both ends. The construction-time `AutoFlush` then writes zero bytes, `FlushFileBuffers` returns immediately, and the request/response proceeds normally. No protocol or wire-format change (the reader already strips a BOM if present, so this is backward compatible).

## Notes / possible follow-up (not in this PR)

The client's timeout is also ineffective: `CancellationTokenSource(timeoutMs)` is passed to `ReadLineAsync`, but a pending async read on `NamedPipeClientStream` doesn't observe the token, so on any genuine failure the CLI hangs instead of erroring out after the timeout. Worth a separate fix (e.g. cancel via the pipe or a `Task.WhenAny` timeout). The deadlock fix in this PR is what makes the CLI functional again.
