### PR TITLE
Fix: cmux CLI hangs instead of timing out when the app is unresponsive

### DIFF
--- a/src/Cmux.Core/IPC/NamedPipeServer.cs
+++ b/src/Cmux.Core/IPC/NamedPipeServer.cs
@@ -11,6 +11,15 @@ namespace Cmux.Core.IPC;
 /// </summary>
 public sealed class NamedPipeServer : IDisposable
 {
+    // UTF-8 WITHOUT a BOM. Using Encoding.UTF8 (which emits a BOM) together with
+    // StreamWriter { AutoFlush = true } makes the AutoFlush setter flush the 3-byte
+    // BOM preamble at construction time. On a Windows named pipe StreamWriter.Flush ->
+    // PipeStream.Flush -> FlushFileBuffers blocks until the peer drains the pipe.
+    // Because both ends construct their writer before their first read, each blocks
+    // waiting for the other to read -> mutual deadlock (no command ever executes).
+    // A BOM-less encoding makes that initial flush a no-op and avoids the deadlock.
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     private readonly string _pipeName;
     private CancellationTokenSource? _cts;
     private Task? _listenTask;
@@ -70,8 +79,8 @@ public sealed class NamedPipeServer : IDisposable
         {
             using (pipe)
             {
-                using var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
-                using var writer = new StreamWriter(pipe, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+                using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
+                using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
 
                 var requestLine = await reader.ReadLineAsync(ct);
                 if (string.IsNullOrEmpty(requestLine)) return;
@@ -208,6 +217,10 @@ public sealed class NamedPipeServer : IDisposable
 /// </summary>
 public static class NamedPipeClient
 {
+    // See NamedPipeServer.Utf8NoBom: a BOM would be flushed at writer construction
+    // (AutoFlush) and deadlock against FlushFileBuffers on the Windows named pipe.
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     public static async Task<string> SendCommand(string command, Dictionary<string, string>? args = null, string? tag = null, int timeoutMs = 5000)
     {
         var pipeName = string.IsNullOrEmpty(tag) ? "cmux" : $"cmux-{tag}";
@@ -217,8 +230,8 @@ public static class NamedPipeClient
 
         await pipe.ConnectAsync(cts.Token);
 
-        using var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
-        using var writer = new StreamWriter(pipe, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+        using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
+        using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
 
         var sb = new StringBuilder(command);
         if (args != null)

--- a/src/Cmux.Core/IPC/NamedPipeServer.cs
+++ b/src/Cmux.Core/IPC/NamedPipeServer.cs
@@ -228,24 +228,44 @@ public static class NamedPipeClient
         using var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
         using var cts = new CancellationTokenSource(timeoutMs);
 
-        await pipe.ConnectAsync(cts.Token);
-
-        using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
-        using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
-
-        var sb = new StringBuilder(command);
-        if (args != null)
+        // A pending async ConnectAsync/ReadLineAsync on a NamedPipeClientStream does not
+        // reliably observe token cancellation, so the timeout on its own never unblocks a
+        // stuck call -- the CLI would hang forever waiting for a response that never comes.
+        // Disposing the pipe is what actually aborts the in-flight I/O, so on timeout we tear
+        // the pipe down to force the awaited operation to fault.
+        using var timeoutRegistration = cts.Token.Register(static state =>
         {
-            foreach (var kvp in args)
+            try { ((IDisposable)state!).Dispose(); } catch { /* already disposed */ }
+        }, pipe);
+
+        try
+        {
+            await pipe.ConnectAsync(cts.Token);
+
+            using var reader = new StreamReader(pipe, Utf8NoBom, leaveOpen: true);
+            using var writer = new StreamWriter(pipe, Utf8NoBom, leaveOpen: true) { AutoFlush = true };
+
+            var sb = new StringBuilder(command);
+            if (args != null)
             {
-                var value = kvp.Value.Contains(' ') ? $"\"{kvp.Value}\"" : kvp.Value;
-                sb.Append($" {kvp.Key}={value}");
+                foreach (var kvp in args)
+                {
+                    var value = kvp.Value.Contains(' ') ? $"\"{kvp.Value}\"" : kvp.Value;
+                    sb.Append($" {kvp.Key}={value}");
+                }
             }
+
+            await writer.WriteLineAsync(sb.ToString());
+
+            var response = await reader.ReadLineAsync(cts.Token);
+            return response ?? "";
         }
-
-        await writer.WriteLineAsync(sb.ToString());
-
-        var response = await reader.ReadLineAsync(cts.Token);
-        return response ?? "";
+        catch (Exception ex) when (cts.IsCancellationRequested)
+        {
+            // Normalize cancellation / pipe teardown (OperationCanceled, ObjectDisposed,
+            // IOException) into a single timeout error so the CLI's existing TimeoutException
+            // handler reports "Could not connect to cmux. Is it running?" instead of hanging.
+            throw new TimeoutException($"cmux did not respond within {timeoutMs} ms.", ex);
+        }
     }
 }


### PR DESCRIPTION
## Problem

Even once the pipe deadlock is fixed, the CLI has a second hang: its timeout never fires. `NamedPipeClient.SendCommand` does

```csharp
using var cts = new CancellationTokenSource(timeoutMs);
await pipe.ConnectAsync(cts.Token);
...
var response = await reader.ReadLineAsync(cts.Token);
```

A pending async read on a `NamedPipeClientStream` does **not** observe token cancellation, so the `timeoutMs` deadline has no effect. If the app accepts the connection but never produces a response — or no app is running at all — the CLI blocks **indefinitely** instead of erroring out.

## Fix

Register a callback on the timeout token that **disposes the pipe**. Disposing is what actually aborts the in-flight `ConnectAsync`/`ReadLineAsync`. The resulting cancellation/teardown exception is normalized into a single `TimeoutException`, so `Program.Main`'s existing handler prints `Could not connect to cmux. Is it running?` instead of hanging.

```csharp
using var timeoutRegistration = cts.Token.Register(static state =>
{
    try { ((IDisposable)state!).Dispose(); } catch { }
}, pipe);

try
{
    await pipe.ConnectAsync(cts.Token);
    // ... write request, read response ...
}
catch (Exception ex) when (cts.IsCancellationRequested)
{
    throw new TimeoutException($"cmux did not respond within {timeoutMs} ms.", ex);
}
```

## Verification

Tested against the real `Cmux.Core` `NamedPipeServer`/`NamedPipeClient`:

| scenario | before | after |
|---|---|---|
| normal round-trip | ~9 ms | ~9 ms (unchanged) |
| server connected, never responds | **hangs forever** | `TimeoutException` at ~1.5 s |
| no server running | **hangs forever** | `TimeoutException` at ~1.5 s |

## Note

This **builds on #16** (the BOM/`AutoFlush` `FlushFileBuffers` deadlock fix) — both touch `NamedPipeClient.SendCommand`. The first commit in this PR is #16's fix; it will drop out of this diff once #16 is merged. Please merge #16 first, or merge this PR which contains both fixes.
