### PR TITLE
Fix CJK cell widths and Ctrl+D pane split shortcut

### DIFF
--- a/src/Cmux.Core/Terminal/TerminalAttribute.cs
+++ b/src/Cmux.Core/Terminal/TerminalAttribute.cs
@@ -109,7 +109,7 @@ public struct TerminalCell
     public char Character;
     public TerminalAttribute Attribute;
     public bool IsDirty;
-    public int Width; // 1 for normal, 2 for wide chars
+    public int Width; // 0 for wide-char continuation, 1 for normal, 2 for wide chars
 
     public static TerminalCell Empty => new()
     {

--- a/src/Cmux.Core/Terminal/TerminalBuffer.cs
+++ b/src/Cmux.Core/Terminal/TerminalBuffer.cs
@@ -105,13 +105,21 @@ public class TerminalBuffer
     public void SetChar(int row, int col, char ch, TerminalAttribute attr)
     {
         if (row < 0 || row >= Rows || col < 0 || col >= Cols) return;
+        int width = GetCharacterCellWidth(ch);
+        if (width <= 0) return;
+        if (col + width > Cols) width = 1;
+
+        ClearCellRange(row, col, width);
         _cells[row, col] = new TerminalCell
         {
             Character = ch,
             Attribute = attr,
             IsDirty = true,
-            Width = 1,
+            Width = width,
         };
+
+        if (width == 2)
+            _cells[row, col + 1] = CreateContinuationCell(attr);
     }
 
     /// <summary>
@@ -123,6 +131,10 @@ public class TerminalBuffer
         if (!ClampCursorToBounds())
             return;
 
+        int width = GetCharacterCellWidth(c);
+        if (width <= 0)
+            return;
+
         if (_wrapPending && AutoWrapMode)
         {
             CarriageReturn();
@@ -130,31 +142,42 @@ public class TerminalBuffer
             _wrapPending = false;
         }
 
-        if (InsertMode)
+        if (width == 2 && CursorCol == Cols - 1 && AutoWrapMode)
         {
-            // Shift characters right
-            for (int col = Cols - 1; col > CursorCol; col--)
-                _cells[CursorRow, col] = _cells[CursorRow, col - 1];
+            CarriageReturn();
+            LineFeed();
         }
 
         if (CursorRow >= 0 && CursorRow < Rows && CursorCol >= 0 && CursorCol < Cols)
         {
+            if (CursorCol + width > Cols)
+                width = 1;
+
+            if (InsertMode)
+                InsertBlankCells(CursorRow, CursorCol, width);
+
+            ClearCellRange(CursorRow, CursorCol, width);
             _cells[CursorRow, CursorCol] = new TerminalCell
             {
                 Character = c,
                 Attribute = CurrentAttribute,
                 IsDirty = true,
-                Width = 1,
+                Width = width,
             };
+
+            if (width == 2)
+                _cells[CursorRow, CursorCol + 1] = CreateContinuationCell(CurrentAttribute);
+
+            NormalizeWideCellsInRow(CursorRow);
         }
 
-        if (CursorCol + 1 >= Cols)
+        if (CursorCol + width >= Cols)
         {
             _wrapPending = true;
         }
         else
         {
-            CursorCol++;
+            CursorCol += width;
         }
     }
 
@@ -262,8 +285,7 @@ public class TerminalBuffer
         switch (mode)
         {
             case 0: // Cursor to end
-                for (int c = CursorCol; c < Cols; c++)
-                    _cells[CursorRow, c] = TerminalCell.Empty;
+                ClearCellRange(CursorRow, CursorCol, Cols - CursorCol);
                 for (int r = CursorRow + 1; r < Rows; r++)
                     for (int c = 0; c < Cols; c++)
                         _cells[r, c] = TerminalCell.Empty;
@@ -272,8 +294,7 @@ public class TerminalBuffer
                 for (int r = 0; r < CursorRow; r++)
                     for (int c = 0; c < Cols; c++)
                         _cells[r, c] = TerminalCell.Empty;
-                for (int c = 0; c <= CursorCol; c++)
-                    _cells[CursorRow, c] = TerminalCell.Empty;
+                ClearCellRange(CursorRow, 0, CursorCol + 1);
                 break;
             case 2: // All
                 Clear();
@@ -299,12 +320,10 @@ public class TerminalBuffer
         switch (mode)
         {
             case 0:
-                for (int c = CursorCol; c < Cols; c++)
-                    _cells[CursorRow, c] = TerminalCell.Empty;
+                ClearCellRange(CursorRow, CursorCol, Cols - CursorCol);
                 break;
             case 1:
-                for (int c = 0; c <= CursorCol; c++)
-                    _cells[CursorRow, c] = TerminalCell.Empty;
+                ClearCellRange(CursorRow, 0, CursorCol + 1);
                 break;
             case 2:
                 for (int c = 0; c < Cols; c++)
@@ -321,8 +340,7 @@ public class TerminalBuffer
             return;
 
         count = Math.Max(0, count);
-        for (int i = 0; i < count && CursorCol + i < Cols; i++)
-            _cells[CursorRow, CursorCol + i] = TerminalCell.Empty;
+        ClearCellRange(CursorRow, CursorCol, count);
         RaiseContentChanged();
     }
 
@@ -368,13 +386,7 @@ public class TerminalBuffer
         if (!ClampCursorToBounds())
             return;
 
-        count = Math.Max(0, count);
-        for (int n = 0; n < count; n++)
-        {
-            for (int c = Cols - 1; c > CursorCol; c--)
-                _cells[CursorRow, c] = _cells[CursorRow, c - 1];
-            _cells[CursorRow, CursorCol] = TerminalCell.Empty;
-        }
+        InsertBlankCells(CursorRow, CursorCol, count);
         RaiseContentChanged();
     }
 
@@ -383,13 +395,7 @@ public class TerminalBuffer
         if (!ClampCursorToBounds())
             return;
 
-        count = Math.Max(0, count);
-        for (int n = 0; n < count; n++)
-        {
-            for (int c = CursorCol; c < Cols - 1; c++)
-                _cells[CursorRow, c] = _cells[CursorRow, c + 1];
-            _cells[CursorRow, Cols - 1] = TerminalCell.Empty;
-        }
+        DeleteCells(CursorRow, CursorCol, count);
         RaiseContentChanged();
     }
 
@@ -550,6 +556,9 @@ public class TerminalBuffer
         CursorRow = Math.Min(CursorRow, newRows - 1);
         CursorCol = Math.Min(CursorCol, newCols - 1);
 
+        for (int row = 0; row < Rows; row++)
+            NormalizeWideCellsInRow(row);
+
         RaiseContentChanged();
     }
 
@@ -611,18 +620,9 @@ public class TerminalBuffer
         int rowCount = Math.Min(Rows, snapshot.ScreenLines.Count);
         for (int row = 0; row < rowCount; row++)
         {
-            var text = snapshot.ScreenLines[row];
-            int colCount = Math.Min(Cols, text.Length);
-            for (int col = 0; col < colCount; col++)
-            {
-                _cells[row, col] = new TerminalCell
-                {
-                    Character = text[col],
-                    Attribute = TerminalAttribute.Default,
-                    IsDirty = true,
-                    Width = 1,
-                };
-            }
+            var line = TextToLine(snapshot.ScreenLines[row], Cols);
+            for (int col = 0; col < Cols; col++)
+                _cells[row, col] = line[col];
         }
 
         CursorRow = Math.Clamp(snapshot.CursorRow, 0, Rows - 1);
@@ -644,14 +644,17 @@ public class TerminalBuffer
 
     private static string LineToText(TerminalCell[] line, int cols)
     {
-        var chars = new char[cols];
+        var text = new System.Text.StringBuilder(cols);
         for (int i = 0; i < cols; i++)
         {
+            if (i < line.Length && line[i].Width == 0)
+                continue;
+
             var ch = i < line.Length ? line[i].Character : ' ';
-            chars[i] = ch == '\0' ? ' ' : ch;
+            text.Append(ch == '\0' ? ' ' : ch);
         }
 
-        return new string(chars).TrimEnd();
+        return text.ToString().TrimEnd();
     }
 
     private static TerminalCell[] TextToLine(string? text, int cols)
@@ -662,19 +665,176 @@ public class TerminalBuffer
 
         if (string.IsNullOrEmpty(text)) return line;
 
-        int len = Math.Min(cols, text.Length);
-        for (int i = 0; i < len; i++)
+        int col = 0;
+        for (int i = 0; i < text.Length && col < cols; i++)
         {
-            line[i] = new TerminalCell
+            int width = GetCharacterCellWidth(text[i]);
+            if (width <= 0)
+                continue;
+            if (col + width > cols)
+                break;
+
+            line[col] = new TerminalCell
             {
                 Character = text[i],
                 Attribute = TerminalAttribute.Default,
                 IsDirty = true,
-                Width = 1,
+                Width = width,
             };
+
+            if (width == 2)
+                line[col + 1] = CreateContinuationCell(TerminalAttribute.Default);
+
+            col += width;
         }
 
         return line;
+    }
+
+    public static int GetCharacterCellWidth(char c)
+    {
+        if (c == '\0' || char.IsControl(c))
+            return 0;
+
+        return IsWideCharacter(c) ? 2 : 1;
+    }
+
+    private static bool IsWideCharacter(char c)
+    {
+        int code = c;
+        return (code >= 0x1100 && code <= 0x115F)
+            || code is 0x2329 or 0x232A
+            || (code >= 0x2E80 && code <= 0xA4CF)
+            || (code >= 0xAC00 && code <= 0xD7A3)
+            || (code >= 0xF900 && code <= 0xFAFF)
+            || (code >= 0xFE10 && code <= 0xFE19)
+            || (code >= 0xFE30 && code <= 0xFE6F)
+            || (code >= 0xFF00 && code <= 0xFF60)
+            || (code >= 0xFFE0 && code <= 0xFFE6);
+    }
+
+    private static TerminalCell CreateContinuationCell(TerminalAttribute attr) => new()
+    {
+        Character = ' ',
+        Attribute = attr,
+        IsDirty = true,
+        Width = 0,
+    };
+
+    private void InsertBlankCells(int row, int startCol, int count)
+    {
+        if (row < 0 || row >= Rows)
+            return;
+
+        count = Math.Clamp(count, 0, Cols - Math.Clamp(startCol, 0, Cols - 1));
+        if (count == 0)
+            return;
+
+        int start = Math.Clamp(startCol, 0, Cols - 1);
+        ClearWideCharacterCrossingColumn(row, start);
+
+        for (int col = Cols - 1; col >= start + count; col--)
+            _cells[row, col] = _cells[row, col - count];
+        for (int col = start; col < start + count; col++)
+            _cells[row, col] = TerminalCell.Empty;
+
+        NormalizeWideCellsInRow(row);
+    }
+
+    private void DeleteCells(int row, int startCol, int count)
+    {
+        if (row < 0 || row >= Rows)
+            return;
+
+        count = Math.Clamp(count, 0, Cols - Math.Clamp(startCol, 0, Cols - 1));
+        if (count == 0)
+            return;
+
+        var (start, deleteCount) = ExpandRangeToWholeWideCells(row, startCol, count);
+        for (int col = start; col < Cols - deleteCount; col++)
+            _cells[row, col] = _cells[row, col + deleteCount];
+        for (int col = Cols - deleteCount; col < Cols; col++)
+            _cells[row, col] = TerminalCell.Empty;
+
+        NormalizeWideCellsInRow(row);
+    }
+
+    private void ClearWideCharacterCrossingColumn(int row, int col)
+    {
+        if (col <= 0 || col >= Cols)
+            return;
+
+        if (_cells[row, col].Width == 0 && _cells[row, col - 1].Width == 2)
+        {
+            _cells[row, col - 1] = TerminalCell.Empty;
+            _cells[row, col] = TerminalCell.Empty;
+        }
+    }
+
+    private (int start, int count) ExpandRangeToWholeWideCells(int row, int startCol, int count)
+    {
+        int start = Math.Clamp(startCol, 0, Cols - 1);
+        int end = Math.Clamp(startCol + count - 1, 0, Cols - 1);
+
+        if (_cells[row, start].Width == 0 && start > 0 && _cells[row, start - 1].Width == 2)
+            start--;
+
+        if (_cells[row, end].Width == 2 && end + 1 < Cols)
+            end++;
+
+        return (start, end - start + 1);
+    }
+
+    private void ClearCellRange(int row, int startCol, int count)
+    {
+        if (row < 0 || row >= Rows || count <= 0)
+            return;
+
+        int start = Math.Clamp(startCol, 0, Cols - 1);
+        int end = Math.Clamp(startCol + count - 1, 0, Cols - 1);
+
+        if (_cells[row, start].Width == 0 && start > 0)
+            start--;
+
+        if (start > 0 && _cells[row, start - 1].Width == 2)
+            start--;
+
+        if (_cells[row, end].Width == 2 && end + 1 < Cols)
+            end++;
+
+        for (int col = start; col <= end; col++)
+            _cells[row, col] = TerminalCell.Empty;
+    }
+
+    private void NormalizeWideCellsInRow(int row)
+    {
+        if (row < 0 || row >= Rows)
+            return;
+
+        for (int col = 0; col < Cols; col++)
+        {
+            var cell = _cells[row, col];
+            if (cell.Width == 2)
+            {
+                if (col + 1 >= Cols)
+                {
+                    _cells[row, col] = TerminalCell.Empty;
+                    continue;
+                }
+
+                _cells[row, col + 1] = CreateContinuationCell(cell.Attribute);
+                col++;
+            }
+            else if (cell.Width == 0)
+            {
+                if (col == 0 || _cells[row, col - 1].Width != 2)
+                    _cells[row, col] = TerminalCell.Empty;
+            }
+            else if (cell.Width != 1)
+            {
+                _cells[row, col] = TerminalCell.Empty;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Cmux.Core/Terminal/TerminalSelection.cs
+++ b/src/Cmux.Core/Terminal/TerminalSelection.cs
@@ -107,22 +107,30 @@ public class TerminalSelection
             int startCol = visRow == s.Row ? s.Col : 0;
             int endCol = visRow == e.Row ? e.Col : buffer.Cols - 1;
 
-            for (int col = startCol; col <= endCol && col < buffer.Cols; col++)
+            TerminalCell GetCell(int c)
             {
-                char ch;
                 if (isScrollback)
                 {
                     var line = buffer.GetScrollbackLine(virtualLine);
-                    ch = (line != null && col < line.Length) ? line[col].Character : '\0';
+                    return (line != null && c >= 0 && c < line.Length) ? line[c] : TerminalCell.Empty;
                 }
-                else if (bufferRow >= 0 && bufferRow < buffer.Rows)
-                {
-                    ch = buffer.CellAt(bufferRow, col).Character;
-                }
-                else
-                {
-                    ch = '\0';
-                }
+                if (bufferRow >= 0 && bufferRow < buffer.Rows && c >= 0 && c < buffer.Cols)
+                    return buffer.CellAt(bufferRow, c);
+                return TerminalCell.Empty;
+            }
+
+            if (GetCell(startCol).Width == 0 && startCol > 0)
+                startCol--;
+            if (GetCell(endCol).Width == 2 && endCol + 1 < buffer.Cols)
+                endCol++;
+
+            for (int col = startCol; col <= endCol && col < buffer.Cols; col++)
+            {
+                var cell = GetCell(col);
+                if (cell.Width == 0)
+                    continue;
+
+                var ch = cell.Character;
                 sb.Append(ch == '\0' ? ' ' : ch);
             }
 
@@ -151,19 +159,23 @@ public class TerminalSelection
         bool isScrollback = virtualLine < scrollbackCount;
         int bufferRow = virtualLine - scrollbackCount;
 
-        char GetChar(int c)
+        TerminalCell GetCell(int c)
         {
             if (isScrollback)
             {
                 var line = buffer.GetScrollbackLine(virtualLine);
-                return (line != null && c < line.Length) ? line[c].Character : '\0';
+                return (line != null && c >= 0 && c < line.Length) ? line[c] : TerminalCell.Empty;
             }
-            if (bufferRow >= 0 && bufferRow < buffer.Rows)
-                return buffer.CellAt(bufferRow, c).Character;
-            return '\0';
+            if (bufferRow >= 0 && bufferRow < buffer.Rows && c >= 0 && c < buffer.Cols)
+                return buffer.CellAt(bufferRow, c);
+            return TerminalCell.Empty;
         }
 
+        int NormalizeToWideStart(int c) => GetCell(c).Width == 0 && c > 0 ? c - 1 : c;
+        char GetChar(int c) => GetCell(NormalizeToWideStart(c)).Character;
         bool IsWordChar(char ch) => ch != '\0' && ch != ' ' && (char.IsLetterOrDigit(ch) || ch == '_' || ch == '-');
+
+        col = NormalizeToWideStart(col);
 
         if (!IsWordChar(GetChar(col)))
         {

--- a/src/Cmux.Core/Terminal/UrlDetector.cs
+++ b/src/Cmux.Core/Terminal/UrlDetector.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Cmux.Core.Terminal;
@@ -15,17 +16,50 @@ public static partial class UrlDetector
         return results;
     }
 
+    public static List<(int startCol, int endCol, string url)> FindUrls(TerminalBuffer buffer, int row)
+    {
+        var (line, cellColumns) = GetRowTextWithCellColumns(buffer, row);
+        var results = new List<(int, int, string)>();
+
+        foreach (Match match in UrlPattern().Matches(line))
+        {
+            if (match.Index >= cellColumns.Count)
+                continue;
+
+            var lastIndex = match.Index + match.Length - 1;
+            if (lastIndex >= cellColumns.Count)
+                continue;
+
+            var endCol = cellColumns[lastIndex] + TerminalBuffer.GetCharacterCellWidth(line[lastIndex]) - 1;
+            results.Add((cellColumns[match.Index], endCol, match.Value));
+        }
+
+        return results;
+    }
+
     public static string GetRowText(TerminalBuffer buffer, int row)
     {
-        if (row < 0 || row >= buffer.Rows)
-            return string.Empty;
+        return GetRowTextWithCellColumns(buffer, row).text;
+    }
 
-        var chars = new char[buffer.Cols];
+    private static (string text, List<int> cellColumns) GetRowTextWithCellColumns(TerminalBuffer buffer, int row)
+    {
+        if (row < 0 || row >= buffer.Rows)
+            return (string.Empty, []);
+
+        var text = new StringBuilder(buffer.Cols);
+        var cellColumns = new List<int>(buffer.Cols);
+
         for (int c = 0; c < buffer.Cols; c++)
         {
-            var ch = buffer.CellAt(row, c).Character;
-            chars[c] = ch == '\0' ? ' ' : ch;
+            var cell = buffer.CellAt(row, c);
+            if (cell.Width == 0)
+                continue;
+
+            text.Append(cell.Character == '\0' ? ' ' : cell.Character);
+            cellColumns.Add(c);
         }
-        return new string(chars);
+
+        return (text.ToString(), cellColumns);
     }
 }

--- a/src/Cmux/Controls/TerminalControl.cs
+++ b/src/Cmux/Controls/TerminalControl.cs
@@ -443,7 +443,9 @@ public class TerminalControl : FrameworkElement
 
                     double x = c * _cellWidth;
                     var attr = cell.Attribute;
-                    bool isSelected = _selection.IsSelected(visRow, c);
+                    bool isSelected = _selection.IsSelected(visRow, c)
+                        || (cell.Width == 0 && c > 0 && _selection.IsSelected(visRow, c - 1))
+                        || (cell.Width == 2 && c + 1 < _cols && _selection.IsSelected(visRow, c + 1));
                     bool isInverse = attr.Flags.HasFlag(CellFlags.Inverse) != isSelected;
 
                     // Cell colors
@@ -486,7 +488,7 @@ public class TerminalControl : FrameworkElement
                     }
 
                     // Text batching: group consecutive characters with same visual style
-                    bool hasChar = cell.Character != '\0' && cell.Character != ' ';
+                    bool hasChar = cell.Width > 0 && cell.Character != '\0' && cell.Character != ' ';
                     if (hasChar)
                     {
                         var fgColor = cellFg.IsDefault ? ToWpfColor(_theme.Foreground) : ToWpfColor(cellFg);
@@ -609,7 +611,9 @@ public class TerminalControl : FrameworkElement
         double x = startCol * _cellWidth;
         dc.DrawText(text, new Point(x, y));
 
-        double runWidth = _textRunBuffer.Length * _cellWidth;
+        double runWidth = 0;
+        foreach (var ch in _textRunBuffer.ToString())
+            runWidth += TerminalBuffer.GetCharacterCellWidth(ch) * _cellWidth;
 
         if (underline)
         {
@@ -820,6 +824,9 @@ public class TerminalControl : FrameworkElement
             e.Handled = true;
             return;
         }
+
+        if (ctrl && !shift && !alt && e.Key == Key.D)
+            return;
 
         // Forward Ctrl+letter as control bytes (e.g. Ctrl+X => 0x18) for TUI apps like nano.
         if (ctrl && !modifiers.HasFlag(ModifierKeys.Alt) && TryGetCtrlLetterSequence(e.Key, out var ctrlSequence))
@@ -1229,8 +1236,7 @@ public class TerminalControl : FrameworkElement
             if (row != _lastUrlRow)
             {
                 _lastUrlRow = row;
-                var lineText = UrlDetector.GetRowText(_session.Buffer, row);
-                _cachedRowUrls = UrlDetector.FindUrls(lineText);
+                _cachedRowUrls = UrlDetector.FindUrls(_session.Buffer, row);
             }
 
             // Check cached URLs for hit at current column

--- a/src/Cmux/Views/MainWindow.xaml.cs
+++ b/src/Cmux/Views/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using Cmux.Controls;
 using Cmux.Core.Services;
+using Cmux.Core.Terminal;
 using Cmux.ViewModels;
 using Cmux.Services;
 
@@ -423,6 +424,13 @@ public partial class MainWindow : Window
             }
         }
 
+        if (ctrl && !shift && !alt && e.Key == Key.D)
+        {
+            ViewModel.SelectedWorkspace?.SelectedSurface?.SplitRight();
+            e.Handled = true;
+            return;
+        }
+
         // === Ctrl-only shortcuts (skip when terminal has focus to let terminal handle them) ===
         if (ctrl && !alt && IsTerminalFocusActive())
             return;
@@ -452,10 +460,6 @@ public partial class MainWindow : Window
                     var surface = ViewModel.SelectedWorkspace?.SelectedSurface;
                     if (surface != null)
                         ViewModel.SelectedWorkspace?.CloseSurface(surface);
-                    e.Handled = true;
-                    return;
-                case Key.D: // Split right
-                    ViewModel.SelectedWorkspace?.SelectedSurface?.SplitRight();
                     e.Handled = true;
                     return;
                 // Workspace 1-8
@@ -1320,26 +1324,34 @@ public partial class MainWindow : Window
 
         for (int row = 0; row < buffer.Rows; row++)
         {
-            var lineText = GetRowText(buffer, row);
+            var (lineText, cellColumns) = GetSearchableRowText(buffer, row);
             int idx = 0;
             while ((idx = lineText.IndexOf(query, idx, StringComparison.OrdinalIgnoreCase)) >= 0)
             {
-                matches.Add((row, idx, query.Length));
+                int startCol = cellColumns[idx];
+                int lastCharCol = cellColumns[idx + query.Length - 1];
+                int length = lastCharCol - startCol + TerminalBuffer.GetCharacterCellWidth(lineText[idx + query.Length - 1]);
+                matches.Add((row, startCol, length));
                 idx++;
             }
         }
         return matches;
     }
 
-    private static string GetRowText(Cmux.Core.Terminal.TerminalBuffer buffer, int row)
+    private static (string text, List<int> cellColumns) GetSearchableRowText(Cmux.Core.Terminal.TerminalBuffer buffer, int row)
     {
         var sb = new System.Text.StringBuilder();
+        var cellColumns = new List<int>();
         for (int col = 0; col < buffer.Cols; col++)
         {
             var cell = buffer.CellAt(row, col);
+            if (cell.Width == 0)
+                continue;
+
             sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+            cellColumns.Add(col);
         }
-        return sb.ToString();
+        return (sb.ToString(), cellColumns);
     }
 
     private void ShowTestNotification()

--- a/tests/Cmux.Tests/CoreTests.cs
+++ b/tests/Cmux.Tests/CoreTests.cs
@@ -154,6 +154,151 @@ public class TerminalBufferTests
     }
 
     [Fact]
+    public void WriteString_WideCharactersOccupyTwoCells()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+
+        buffer.WriteString("A中B");
+
+        buffer.CursorCol.Should().Be(4);
+        buffer.CellAt(0, 0).Character.Should().Be('A');
+        buffer.CellAt(0, 0).Width.Should().Be(1);
+        buffer.CellAt(0, 1).Character.Should().Be('中');
+        buffer.CellAt(0, 1).Width.Should().Be(2);
+        buffer.CellAt(0, 2).Character.Should().Be(' ');
+        buffer.CellAt(0, 2).Width.Should().Be(0);
+        buffer.CellAt(0, 3).Character.Should().Be('B');
+    }
+
+    [Fact]
+    public void ExportPlainText_DoesNotPadWideCharacterContinuationCells()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        buffer.WriteString("中文ABC");
+
+        buffer.ExportPlainText().Should().Be("中文ABC");
+    }
+
+    [Fact]
+    public void WriteChar_OverWideCharacterBoundary_ClearsOverlappedCells()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("中文");
+
+        buffer.MoveCursorTo(0, 1);
+        buffer.WriteChar('好');
+
+        AssertWideCellInvariants(buffer);
+        buffer.CellAt(0, 0).Character.Should().Be(' ');
+        buffer.CellAt(0, 1).Character.Should().Be('好');
+        buffer.CellAt(0, 1).Width.Should().Be(2);
+        buffer.CellAt(0, 2).Width.Should().Be(0);
+        buffer.CellAt(0, 3).Character.Should().Be(' ');
+    }
+
+    [Fact]
+    public void EraseChars_FromWideContinuation_ClearsWholeWideCharacter()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A中B");
+
+        buffer.MoveCursorTo(0, 2);
+        buffer.EraseChars(1);
+
+        AssertWideCellInvariants(buffer);
+        buffer.ExportPlainText().Should().Be("A  B");
+    }
+
+    [Fact]
+    public void InsertChars_OnWideCharacterLine_PreservesWideCellInvariants()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A中B");
+
+        buffer.MoveCursorTo(0, 2);
+        buffer.InsertChars(1);
+
+        AssertWideCellInvariants(buffer);
+    }
+
+    [Fact]
+    public void InsertChars_BeforeAscii_PreservesShiftedCharacter()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("ABC");
+
+        buffer.MoveCursorTo(0, 1);
+        buffer.InsertChars(1);
+
+        AssertWideCellInvariants(buffer);
+        buffer.ExportPlainText().Should().Be("A BC");
+    }
+
+    [Fact]
+    public void InsertChars_BeforeWideCharacter_PreservesShiftedWideCharacter()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A\u4E2DB");
+
+        buffer.MoveCursorTo(0, 1);
+        buffer.InsertChars(1);
+
+        AssertWideCellInvariants(buffer);
+        buffer.ExportPlainText().Should().Be("A \u4E2DB");
+    }
+
+    [Fact]
+    public void DeleteChars_OnWideCharacterLine_PreservesWideCellInvariants()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A中B");
+
+        buffer.MoveCursorTo(0, 1);
+        buffer.DeleteChars(1);
+
+        AssertWideCellInvariants(buffer);
+    }
+
+    [Fact]
+    public void DeleteChars_AtWideCharacterStart_RemovesWholeWideCharacter()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A\u4E2DB");
+
+        buffer.MoveCursorTo(0, 1);
+        buffer.DeleteChars(1);
+
+        AssertWideCellInvariants(buffer);
+        buffer.ExportPlainText().Should().Be("AB");
+    }
+
+    [Fact]
+    public void WriteChar_InsertModeAtWideContinuation_PreservesWideCellInvariants()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("A\u4E2DB");
+        buffer.InsertMode = true;
+
+        buffer.MoveCursorTo(0, 2);
+        buffer.WriteChar('X');
+
+        AssertWideCellInvariants(buffer);
+        buffer.CellAt(0, 2).Character.Should().Be('X');
+    }
+
+    [Fact]
+    public void Resize_TruncatingWideCharacter_ClearsIncompleteWideCharacter()
+    {
+        var buffer = new TerminalBuffer(5, 1);
+        buffer.WriteString("AB中");
+
+        buffer.Resize(3, 1);
+
+        AssertWideCellInvariants(buffer);
+        buffer.ExportPlainText().Should().Be("AB");
+    }
+
+    [Fact]
     public void LineFeed_AtBottom_ScrollsUp()
     {
         var buffer = new TerminalBuffer(80, 3);
@@ -218,6 +363,31 @@ public class TerminalBufferTests
 
         buffer.CursorRow.Should().Be(5);
         buffer.CursorCol.Should().Be(10);
+    }
+
+    private static void AssertWideCellInvariants(TerminalBuffer buffer)
+    {
+        for (int row = 0; row < buffer.Rows; row++)
+        {
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                var cell = buffer.CellAt(row, col);
+                if (cell.Width == 2)
+                {
+                    (col + 1).Should().BeLessThan(buffer.Cols);
+                    buffer.CellAt(row, col + 1).Width.Should().Be(0);
+                }
+                else if (cell.Width == 0)
+                {
+                    col.Should().BeGreaterThan(0);
+                    buffer.CellAt(row, col - 1).Width.Should().Be(2);
+                }
+                else
+                {
+                    cell.Width.Should().Be(1);
+                }
+            }
+        }
     }
 }
 
@@ -473,6 +643,31 @@ public class TerminalSelectionTests
     }
 
     [Fact]
+    public void GetSelectedText_FromWideContinuationCell_IncludesWholeCharacter()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        buffer.WriteString("A中B");
+
+        var selection = new TerminalSelection();
+        selection.StartSelection(0, 2);
+        selection.ExtendSelection(0, 2);
+
+        selection.GetSelectedText(buffer).Should().Be("中");
+    }
+
+    [Fact]
+    public void SelectWord_OnWideContinuationCell_SelectsWholeCharacter()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        buffer.WriteString("A中B");
+
+        var selection = new TerminalSelection();
+        selection.SelectWord(buffer, 0, 2);
+
+        selection.GetSelectedText(buffer).Should().Be("A中B");
+    }
+
+    [Fact]
     public void IsSelected_MultiLine_Works()
     {
         var selection = new TerminalSelection();
@@ -617,6 +812,31 @@ public class UrlDetectorTests
         var text = UrlDetector.GetRowText(buffer, 0);
         text.Should().StartWith("Hi");
         text.Should().HaveLength(10);
+    }
+
+    [Fact]
+    public void GetRowText_SkipsWideContinuationCells()
+    {
+        var buffer = new TerminalBuffer(10, 1);
+        buffer.WriteString("中A");
+
+        var text = UrlDetector.GetRowText(buffer, 0);
+
+        text.Should().StartWith("中A");
+        text.Should().HaveLength(9);
+    }
+
+    [Fact]
+    public void FindUrls_BufferRow_MapsColumnsAfterWideCharacters()
+    {
+        var buffer = new TerminalBuffer(40, 1);
+        buffer.WriteString("中 https://example.com");
+
+        var urls = UrlDetector.FindUrls(buffer, 0);
+
+        urls.Should().HaveCount(1);
+        urls[0].url.Should().Be("https://example.com");
+        urls[0].startCol.Should().Be(3);
     }
 }
 


### PR DESCRIPTION
## Summary

This is a focused fix for the terminal rendering and shortcut issues I hit on Windows:

- Treat CJK/full-width characters as two terminal cells in `TerminalBuffer`.
- Store a continuation cell with `Width = 0`, and keep wide-cell invariants intact when writing, erasing, inserting, deleting, resizing, copying, snapshotting, searching, and URL-detecting rows.
- Render text runs, selection highlighting, search highlights, and URL hover positions using terminal cell columns instead of assuming one UTF-16 char equals one terminal cell.
- Let `Ctrl+D` reach `MainWindow` and trigger the documented `SplitRight()` shortcut even when the terminal control has focus.

## Notes

This addresses the display/cell-width portion of #3. It does **not** attempt to fix TSF/IME composition for Korean or other IME input paths.

There is overlap with the CJK portion of #5, but that PR is a broad P0/P1 bundle across IPC/security/threading/secrets/VT parsing. This PR is intentionally smaller and based on the current `main`, with tests focused on the wide-cell behavior.

`Ctrl+D` now consistently means split-right in the app, matching the README and CLI help. The tradeoff is that focused terminals no longer receive `Ctrl+D` as shell EOF through this key path.

## Verification

- `dotnet test Cmux.sln -c Debug --no-restore` -> 68/68 passed
- `dotnet build Cmux.sln -c Debug --no-restore` -> 0 warnings, 0 errors
- `dotnet publish src/Cmux/Cmux.csproj -c Release -r win-x64 --self-contained false -o publish/cmux-win-x64-verify`
- `dotnet publish src/Cmux.Cli/Cmux.Cli.csproj -c Release -r win-x64 --self-contained true -o publish/cmux-cli-verify`
- `publish/cmux-cli-verify/cmux.exe --help`