### PR TITLE
feat: add app-wide high-DPI UI scaling controls

### DIFF
--- a/src/Cmux.Core/Config/CmuxSettings.cs
+++ b/src/Cmux.Core/Config/CmuxSettings.cs
@@ -10,6 +10,7 @@ public class CmuxSettings
 
     public string FontFamily { get; set; } = "Cascadia Code";
     public int FontSize { get; set; } = 14;
+    public int UiScalePercent { get; set; } = 100;
     public string ThemeName { get; set; } = "Default Dark";
     public bool UseCustomTerminalColors { get; set; } = false;
     public string CustomTerminalBackground { get; set; } = "";

--- a/src/Cmux/Views/MainWindow.xaml
+++ b/src/Cmux/Views/MainWindow.xaml
@@ -180,6 +180,10 @@
                                 <MenuItem Header="Command _Palette" Click="CommandPalette_Click" InputGestureText="Ctrl+Shift+P" />
                                 <MenuItem Header="_Snippets" Click="Snippets_Click" />
                                 <Separator />
+                                <MenuItem Header="UI Scale _Up" Click="MenuUiScaleUp_Click" InputGestureText="Ctrl+=" />
+                                <MenuItem Header="UI Scale _Down" Click="MenuUiScaleDown_Click" InputGestureText="Ctrl+-" />
+                                <MenuItem Header="_Reset UI Scale" Click="MenuUiScaleReset_Click" InputGestureText="Ctrl+0" />
+                                <Separator />
                                 <MenuItem Header="Toggle Agent _Chat" Click="MenuToggleAgentChat_Click" InputGestureText="Ctrl+Shift+A" />
                                 <MenuItem Header="Toggle _Sidebar" Command="{Binding ToggleSidebarCommand}" InputGestureText="Ctrl+B" />
                             </MenuItem>

--- a/src/Cmux/Views/MainWindow.xaml.cs
+++ b/src/Cmux/Views/MainWindow.xaml.cs
@@ -424,6 +424,28 @@ public partial class MainWindow : Window
         }
 
         // === Ctrl-only shortcuts (skip when terminal has focus to let terminal handle them) ===
+        if (ctrl && !shift && !alt)
+        {
+            switch (e.Key)
+            {
+                case Key.OemPlus:
+                case Key.Add:
+                    IncreaseUiScale();
+                    e.Handled = true;
+                    return;
+                case Key.OemMinus:
+                case Key.Subtract:
+                    DecreaseUiScale();
+                    e.Handled = true;
+                    return;
+                case Key.D0:
+                case Key.NumPad0:
+                    ResetUiScale();
+                    e.Handled = true;
+                    return;
+            }
+        }
+
         if (ctrl && !alt && IsTerminalFocusActive())
             return;
 
@@ -497,6 +519,18 @@ public partial class MainWindow : Window
 
     private void MinimizeButton_Click(object sender, RoutedEventArgs e) =>
         WindowState = WindowState.Minimized;
+
+    private void IncreaseUiScale() => WindowAppearance.IncreaseUiScale();
+
+    private void DecreaseUiScale() => WindowAppearance.DecreaseUiScale();
+
+    private void ResetUiScale() => WindowAppearance.ResetUiScale();
+
+    private void MenuUiScaleUp_Click(object sender, RoutedEventArgs e) => IncreaseUiScale();
+
+    private void MenuUiScaleDown_Click(object sender, RoutedEventArgs e) => DecreaseUiScale();
+
+    private void MenuUiScaleReset_Click(object sender, RoutedEventArgs e) => ResetUiScale();
 
     private void MaximizeButton_Click(object sender, RoutedEventArgs e) =>
         WindowState = WindowState == WindowState.Maximized

--- a/src/Cmux/Views/SettingsWindow.xaml
+++ b/src/Cmux/Views/SettingsWindow.xaml
@@ -367,6 +367,27 @@
                             </StackPanel>
                         </Grid>
 
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="160" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="UI Scale" Style="{StaticResource SectionLabel}" />
+                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                <Slider x:Name="UiScaleSlider" Minimum="100" Maximum="200"
+                                        Width="220" VerticalAlignment="Center"
+                                        TickFrequency="10" IsSnapToTickEnabled="True"
+                                        ValueChanged="UiScaleSlider_ValueChanged" />
+                                <TextBlock x:Name="UiScaleValueText" Foreground="{StaticResource ForegroundDimBrush}"
+                                           VerticalAlignment="Center" Margin="10,0,0,0" FontSize="12" />
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Margin="160,0,0,12"
+                                   Foreground="{StaticResource ForegroundDimBrush}"
+                                   FontSize="12"
+                                   Text="Scales the full app UI for 4K/high-DPI displays. Shortcuts: Ctrl+=, Ctrl+-, Ctrl+0." />
+
                         <!-- Theme -->
                         <Grid Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>

--- a/src/Cmux/Views/SettingsWindow.xaml.cs
+++ b/src/Cmux/Views/SettingsWindow.xaml.cs
@@ -66,6 +66,8 @@ public partial class SettingsWindow : Window
 
         FontSizeSlider.Value = Math.Clamp(s.FontSize, 9, 28);
         UpdateFontSizeText();
+        UiScaleSlider.Value = Math.Clamp(s.UiScalePercent, 100, 200);
+        UpdateUiScaleText();
 
         _suppressThemeSync = true;
         ThemeCombo.SelectedItem = s.ThemeName;
@@ -184,6 +186,7 @@ public partial class SettingsWindow : Window
         var s = SettingsService.Current;
         s.FontFamily = FontFamilyCombo.SelectedItem as string ?? FontFamilyCombo.Text;
         s.FontSize = (int)Math.Round(FontSizeSlider.Value);
+        s.UiScalePercent = (int)Math.Round(UiScaleSlider.Value);
         s.ThemeName = TerminalThemePresetCombo.SelectedItem as string
             ?? ThemeCombo.SelectedItem as string
             ?? "Default Dark";
@@ -874,6 +877,12 @@ public partial class SettingsWindow : Window
             FontSizeValueText.Text = $"{(int)Math.Round(FontSizeSlider.Value)} px";
     }
 
+    private void UpdateUiScaleText()
+    {
+        if (UiScaleValueText != null)
+            UiScaleValueText.Text = $"{(int)Math.Round(UiScaleSlider.Value)}%";
+    }
+
     private void OpacitySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
     {
         UpdateOpacityText();
@@ -882,6 +891,11 @@ public partial class SettingsWindow : Window
     private void FontSizeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
     {
         UpdateFontSizeText();
+    }
+
+    private void UiScaleSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        UpdateUiScaleText();
     }
 
     private static string? NormalizeHexColor(string? text)

--- a/src/Cmux/Views/WindowAppearance.cs
+++ b/src/Cmux/Views/WindowAppearance.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
+using Cmux.Core.Config;
 
 namespace Cmux.Views;
 
@@ -51,6 +54,22 @@ internal static class WindowAppearance
         public POINT ptMaxTrackSize;
     }
 
+    private sealed class UiScaleState
+    {
+        public FrameworkElement? RootElement;
+        public ScaleTransform? Transform;
+        public double BaseWidth;
+        public double BaseHeight;
+        public double BaseMinWidth;
+        public double BaseMinHeight;
+        public double CurrentScale = 1.0;
+        public bool IsInitialized;
+        public bool IsUpdating;
+        public Action? SettingsChangedHandler;
+    }
+
+    private static readonly Dictionary<Window, UiScaleState> UiScaleStates = [];
+
     public static void Apply(Window window)
     {
         window.SourceInitialized += (_, _) =>
@@ -76,6 +95,141 @@ internal static class WindowAppearance
                 // Best effort: ignore on unsupported systems.
             }
         };
+
+        AttachUiScaling(window);
+    }
+
+    public static void IncreaseUiScale() => SetUiScalePercent(SettingsService.Current.UiScalePercent + 10);
+
+    public static void DecreaseUiScale() => SetUiScalePercent(SettingsService.Current.UiScalePercent - 10);
+
+    public static void ResetUiScale() => SetUiScalePercent(100);
+
+    private static void SetUiScalePercent(int percent)
+    {
+        percent = Math.Clamp(percent, 100, 200);
+
+        var settings = SettingsService.Current;
+        if (settings.UiScalePercent == percent)
+            return;
+
+        settings.UiScalePercent = percent;
+        SettingsService.Save(settings);
+        SettingsService.NotifyChanged();
+    }
+
+    private static double GetUiScaleFactor()
+    {
+        return Math.Clamp(SettingsService.Current.UiScalePercent, 100, 200) / 100.0;
+    }
+
+    private static void AttachUiScaling(Window window)
+    {
+        if (UiScaleStates.ContainsKey(window))
+            return;
+
+        var state = new UiScaleState();
+        UiScaleStates[window] = state;
+
+        window.Loaded += (_, _) => ApplyUiScale(window, state, captureBaseMetrics: true);
+        window.SizeChanged += (_, _) => UpdateBaseSizeMetrics(window, state);
+        window.Closed += (_, _) =>
+        {
+            if (state.SettingsChangedHandler != null)
+                SettingsService.SettingsChanged -= state.SettingsChangedHandler;
+            UiScaleStates.Remove(window);
+        };
+
+        state.SettingsChangedHandler = () =>
+        {
+            if (window.Dispatcher.HasShutdownStarted)
+                return;
+
+            _ = window.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (!window.IsLoaded)
+                    return;
+
+                ApplyUiScale(window, state, captureBaseMetrics: false);
+            }));
+        };
+
+        SettingsService.SettingsChanged += state.SettingsChangedHandler;
+    }
+
+    private static void ApplyUiScale(Window window, UiScaleState state, bool captureBaseMetrics)
+    {
+        if (window.Content is not FrameworkElement root)
+            return;
+
+        if (!state.IsInitialized || !ReferenceEquals(state.RootElement, root))
+        {
+            state.RootElement = root;
+            state.Transform ??= new ScaleTransform(1.0, 1.0);
+            root.LayoutTransform = state.Transform;
+            captureBaseMetrics = true;
+            state.IsInitialized = true;
+        }
+
+        if (captureBaseMetrics)
+            CaptureBaseMetrics(window, state);
+
+        var scale = GetUiScaleFactor();
+        if (Math.Abs(state.CurrentScale - scale) < 0.001 && !captureBaseMetrics)
+            return;
+
+        state.IsUpdating = true;
+        try
+        {
+            state.Transform!.ScaleX = scale;
+            state.Transform.ScaleY = scale;
+
+            if (state.BaseMinWidth > 0)
+                window.MinWidth = state.BaseMinWidth * scale;
+            if (state.BaseMinHeight > 0)
+                window.MinHeight = state.BaseMinHeight * scale;
+
+            if (window.WindowState == WindowState.Normal)
+            {
+                if (state.BaseWidth > 0)
+                    window.Width = state.BaseWidth * scale;
+                if (state.BaseHeight > 0)
+                    window.Height = state.BaseHeight * scale;
+            }
+
+            state.CurrentScale = scale;
+        }
+        finally
+        {
+            state.IsUpdating = false;
+        }
+    }
+
+    private static void CaptureBaseMetrics(Window window, UiScaleState state)
+    {
+        var divisor = Math.Max(0.1, state.CurrentScale);
+        state.BaseWidth = NormalizeBaseMetric(window.Width, window.ActualWidth, divisor);
+        state.BaseHeight = NormalizeBaseMetric(window.Height, window.ActualHeight, divisor);
+        state.BaseMinWidth = NormalizeBaseMetric(window.MinWidth, window.MinWidth, divisor);
+        state.BaseMinHeight = NormalizeBaseMetric(window.MinHeight, window.MinHeight, divisor);
+    }
+
+    private static void UpdateBaseSizeMetrics(Window window, UiScaleState state)
+    {
+        if (!state.IsInitialized || state.IsUpdating || window.WindowState != WindowState.Normal)
+            return;
+
+        var divisor = Math.Max(0.1, state.CurrentScale);
+        if (window.ActualWidth > 0)
+            state.BaseWidth = window.ActualWidth / divisor;
+        if (window.ActualHeight > 0)
+            state.BaseHeight = window.ActualHeight / divisor;
+    }
+
+    private static double NormalizeBaseMetric(double preferredValue, double fallbackValue, double divisor)
+    {
+        var value = double.IsNaN(preferredValue) || preferredValue <= 0 ? fallbackValue : preferredValue;
+        return value > 0 ? value / divisor : 0;
     }
 
     private static nint MaximizeBoundsHook(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)


### PR DESCRIPTION
## Summary
Adds an app-wide UI scaling setting for high-DPI / 4K displays.

## Problem
Some labels and surrounding UI chrome are too small on 4K and high-DPI screens even when terminal font size is increased.

## Changes
- add persisted `UiScalePercent` setting
- apply window-wide scaling through shared window appearance logic
- add `UI Scale` control in `Settings > Appearance`
- add shortcuts:
- `Ctrl+=` increase scale
- `Ctrl+-` decrease scale
- `Ctrl+0` reset scale
- add matching menu items under `Window`

## Why
This makes the app usable on high-resolution displays without depending entirely on Windows display scaling or only   increasing terminal font size.

## Validation
- `dotnet build` succeeded
- `win-x64` self-contained publish succeeded
- runtime UI verification was not performed in this Linux environment

## Screenshots from 4k Pixels / 32 Inch Screen

### Default DPI:

<img width="592"  alt="image" src="https://github.com/user-attachments/assets/1c4801fe-6dba-46c6-b726-fd5d90573c38" />

### Increased DPI: 

<img width="599" alt="image" src="https://github.com/user-attachments/assets/6a8f1182-cbcf-4e8f-aad3-cb1dbb0ffc7f" />

### In Settings > Appearance: 

<img width="543" alt="image" src="https://github.com/user-attachments/assets/36789097-5a2e-40ac-8c4c-5f0ce9688108" />



